### PR TITLE
Compute solver probabilities dynamically from the number of point and line correspondences

### DIFF
--- a/limap/estimators/absolute_pose/hybrid_pose_estimator.h
+++ b/limap/estimators/absolute_pose/hybrid_pose_estimator.h
@@ -87,9 +87,9 @@ public:
 
 private:
     std::vector<bool> solver_flags_;
-    int combination(int n, int m) const {
-        int num = 1;
-        int denom = 1;
+    unsigned long long combination(unsigned n, unsigned m) const {
+        unsigned long long num = 1;
+        unsigned long long denom = 1;
         for (int i = 0; i < m; i++) 
             num *= n - i;
         for (int i = 0; i < m; i++)

--- a/limap/estimators/absolute_pose/hybrid_pose_estimator.h
+++ b/limap/estimators/absolute_pose/hybrid_pose_estimator.h
@@ -46,13 +46,18 @@ public:
         (*num_data)[1] = num_data_lines();
     }
 
-    void solver_probabilities(std::vector<double>* solver_probabilites) const {
-        solver_probabilites->resize(4);
+    void solver_probabilities(std::vector<double>* solver_probabilities) const {
+        std::vector<std::vector<int>> sample_sizes;
+        min_sample_sizes(&sample_sizes);
+        solver_probabilities->resize(4);
+
         for (int i = 0; i < 4; i++) {
             if (!solver_flags_[i])
-                (*solver_probabilites)[i] = 0.0;
-            else
-                (*solver_probabilites)[i] = 1.0;
+                solver_probabilities->at(i) = 0.0;
+            else {
+                solver_probabilities->at(i) = combination(num_data_points(), sample_sizes[i][0]) *
+                                              combination(num_data_lines(), sample_sizes[i][1]);
+            }
         }
     }
 
@@ -82,6 +87,15 @@ public:
 
 private:
     std::vector<bool> solver_flags_;
+    int combination(int n, int m) const {
+        int num = 1;
+        int denom = 1;
+        for (int i = 0; i < m; i++) 
+            num *= n - i;
+        for (int i = 0; i < m; i++)
+            denom *= i + 1;
+        return num / denom;
+    }
 };
 
 std::pair<CameraPose, ransac_lib::HybridRansacStatistics> 

--- a/limap/util/config.py
+++ b/limap/util/config.py
@@ -62,6 +62,8 @@ def update_config(cfg, unknown, shortcuts):
         else:
             v = unknown[idx+1]
             if val is not None:
+                if argtype == list and v.startswith('['):
+                    v = eval(v)
                 v = argtype(v)
 
         if isinstance(v, str) and (v.lower() == 'none' or v.lower() == 'null'):

--- a/runners/tests/localization.py
+++ b/runners/tests/localization.py
@@ -70,6 +70,14 @@ def main():
     final_pose, ransac_stats = _estimators.pl_estimate_absolute_pose(
                 cfg, l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, silent=True, logger=logger)
     
+    # Let's Check some RANSAC status
+    log = "RANSAC stats: \n"
+    log += f"num_iterations_total: {ransac_stats.num_iterations_total}\n"
+    log += f"best_num_inliers: {ransac_stats.best_num_inliers}\n"
+    log += f"best_model_score: {ransac_stats.best_model_score}\n"
+    log += f"inlier_ratios (Points, Lines): {ransac_stats.inlier_ratios}\n"
+    logger.info(log)
+
     R_gt, t_gt = data['pose_gt'].R(), data['pose_gt'].tvec
     
     log = "Results: \n"


### PR DESCRIPTION
- Compute solver probabilities dynamically from the number of point and line correspondences
- Print some RANSAC stats in localization test script
- Support parsing list configs from cmd args