### PR TITLE
allow bigger torch and numpy versions

### DIFF
--- a/limap/point2d/superpoint/main.py
+++ b/limap/point2d/superpoint/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Union, Optional
 import pprint
 
-from torch._six import string_classes
+string_classes = str
 import collections.abc as collections
 
 from hloc import extract_features

--- a/limap/util/io.py
+++ b/limap/util/io.py
@@ -1,4 +1,3 @@
-import torch
 import os, sys
 import numpy as np
 import shutil

--- a/limap/util/io.py
+++ b/limap/util/io.py
@@ -1,3 +1,4 @@
+import torch
 import os, sys
 import numpy as np
 import shutil
@@ -28,7 +29,7 @@ def check_makedirs(folder):
 def save_npy(fname, nparray):
     check_directory(fname)
     with open(fname, 'wb') as f:
-        np.save(f, nparray)
+        np.save(f, np.array(nparray, dtype=object))
 
 def read_npy(fname):
     check_path(fname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml
 tqdm
 attrdict
 h5py
-numpy==1.21.6
+numpy
 scipy
 matplotlib
 seaborn


### PR DESCRIPTION
Right now limap relies on deprecated default behavior for saving arrays of inconsistent shapes with numpy.

On the never versions it crashes with:

```
  File "/Users/ducha-aiki/Repos/3rd-party/limap/limap/line2d/base_detector.py", line 113, in extract_all_images
    self.save_descinfo(descinfo_folder, img_id, descinfo)
  File "/Users/ducha-aiki/Repos/3rd-party/limap/limap/line2d/SOLD2/sold2.py", line 31, in save_descinfo
    limapio.save_npy(fname, descinfo)
  File "/Users/ducha-aiki/Repos/3rd-party/limap/limap/util/io.py", line 31, in save_npy
    np.save(f, nparray)
  File "<__array_function__ internals>", line 200, in save
  File "/Users/ducha-aiki/.pyenv/versions/3.9.16/lib/python3.9/site-packages/numpy/lib/npyio.py", line 521, in save
    arr = np.asanyarray(arr)
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```

This PR fixes this behavior. 

Also, when using PyTorch 2.0 I have errors like

```
  File "/Users/old-ufo/dev/limap/limap/point2d/superpoint/main.py", line 9, in <module>
    from torch._six import string_classes
ModuleNotFoundError: No module named 'torch._six'
```

This PR fixes this as well.