### PR TITLE
Add back overlap check in cheirality test for absolute camera pose estimation

### DIFF
--- a/limap/estimators/absolute_pose/bindings.cc
+++ b/limap/estimators/absolute_pose/bindings.cc
@@ -20,14 +20,28 @@ namespace limap {
 void bind_absolute_pose(py::module& m) {
     using namespace estimators::absolute_pose;
 
+    py::class_<JointPoseEstimatorOptions>(m, "JointPoseEstimatorOptions")
+        .def(py::init<>())
+        .def_readwrite("ransac_options", &JointPoseEstimatorOptions::ransac_options)
+        .def_readwrite("lineloc_config", &JointPoseEstimatorOptions::lineloc_config)
+        .def_readwrite("cheirality_min_depth", &JointPoseEstimatorOptions::cheirality_min_depth)
+        .def_readwrite("cheirality_overlap_pixels", &JointPoseEstimatorOptions::cheirality_overlap_pixels)
+        .def_readwrite("sample_solver_first", &JointPoseEstimatorOptions::sample_solver_first)
+        .def_readwrite("random", &JointPoseEstimatorOptions::random);
+
+    py::class_<HybridPoseEstimatorOptions>(m, "HybridPoseEstimatorOptions")
+        .def(py::init<>())
+        .def_readwrite("ransac_options", &HybridPoseEstimatorOptions::ransac_options)
+        .def_readwrite("lineloc_config", &HybridPoseEstimatorOptions::lineloc_config)
+        .def_readwrite("solver_flags", &HybridPoseEstimatorOptions::solver_flags)
+        .def_readwrite("cheirality_min_depth", &HybridPoseEstimatorOptions::cheirality_min_depth)
+        .def_readwrite("cheirality_overlap_pixels", &HybridPoseEstimatorOptions::cheirality_overlap_pixels)
+        .def_readwrite("random", &HybridPoseEstimatorOptions::random);
+
     m.def("EstimateAbsolutePose_PointLine", &EstimateAbsolutePose_PointLine,
-            "tracks"_a, "l3d_ids"_a, "l2ds"_a, "p3ds"_a, "p2ds"_a, "cam"_a, "cfg"_a, "options_"_a, "sample_solver_first"_a = false,
-            "cheirality_min_depth"_a = 0.0, "line_min_projected_length"_a = 1
-    );
+            "l3ds"_a, "l3d_ids"_a, "l2ds"_a, "p3ds"_a, "p2ds"_a, "cam"_a, "options_"_a);
     m.def("EstimateAbsolutePose_PointLine_Hybrid", &EstimateAbsolutePose_PointLine_Hybrid,
-            "tracks"_a, "l3d_ids"_a, "l2ds"_a, "p3ds"_a, "p2ds"_a, "cam"_a, "cfg"_a, "options_"_a, "solver_flags"_a,
-            "cheirality_min_depth"_a = 0.0, "line_min_projected_length"_a = 1
-    );
+            "l3ds"_a, "l3d_ids"_a, "l2ds"_a, "p3ds"_a, "p2ds"_a, "cam"_a, "options_"_a);
 }
 
 } // namespace limap

--- a/limap/estimators/absolute_pose/hybrid_pose_estimator.cc
+++ b/limap/estimators/absolute_pose/hybrid_pose_estimator.cc
@@ -14,21 +14,20 @@ namespace lineloc = optimize::line_localization;
 std::pair<CameraPose, ransac_lib::HybridRansacStatistics> 
 EstimateAbsolutePose_PointLine_Hybrid(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, const std::vector<Line2d>& l2ds, 
                                       const std::vector<V3D>& p3ds, const std::vector<V2D>& p2ds, const Camera& cam, 
-                                      const ExtendedHybridLORansacOptions& options_, const lineloc::LineLocConfig& cfg, 
-                                      const std::vector<bool>& solver_flags, const double cheirality_min_depth, 
-                                      const double line_min_projected_length) {
-    ExtendedHybridLORansacOptions options = options_;
+                                      const HybridPoseEstimatorOptions &options) {
+    ExtendedHybridLORansacOptions ransac_options = options.ransac_options;
     std::random_device rand_dev;
-    options.random_seed_ = rand_dev();
+    if (options.random)
+        ransac_options.random_seed_ = rand_dev();
 
-    HybridPoseEstimator solver(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, cfg);
-    solver.set_solver_flags(solver_flags);
+    HybridPoseEstimator solver(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, options.lineloc_config, options.cheirality_min_depth, options.cheirality_overlap_pixels);
+    solver.set_solver_flags(options.solver_flags);
 
     PointLineAbsolutePoseHybridRansac<CameraPose, std::vector<CameraPose>, HybridPoseEstimator> hybrid_lomsac;
     CameraPose best_model;
     ransac_lib::HybridRansacStatistics ransac_stats;
 
-    hybrid_lomsac.EstimateModel(options, solver, &best_model, &ransac_stats);
+    hybrid_lomsac.EstimateModel(ransac_options, solver, &best_model, &ransac_stats);
     return std::make_pair(best_model, ransac_stats);
 }
 

--- a/limap/estimators/absolute_pose/hybrid_pose_estimator.h
+++ b/limap/estimators/absolute_pose/hybrid_pose_estimator.h
@@ -24,16 +24,16 @@ public:
     HybridPoseEstimatorOptions() : 
         ransac_options(ExtendedHybridLORansacOptions()),
         lineloc_config(LineLocConfig()),
-        solver_flags(std::vector<bool>{true, true, true, true}),
+        solver_flags({true, true, true, true}),
         cheirality_min_depth(0.0),
         cheirality_overlap_pixels(10.0),
         random(true) {}
 
     ExtendedHybridLORansacOptions ransac_options;
     LineLocConfig lineloc_config;
-    std::vector<bool> solver_flags;
-    double cheirality_min_depth;
-    double cheirality_overlap_pixels;
+    std::vector<bool> solver_flags = {true, true, true, true};
+    double cheirality_min_depth = 0.0;
+    double cheirality_overlap_pixels = 10.0;
     bool random = true;
 };
 

--- a/limap/estimators/absolute_pose/hybrid_pose_estimator.h
+++ b/limap/estimators/absolute_pose/hybrid_pose_estimator.h
@@ -19,14 +19,32 @@ namespace estimators {
 
 namespace absolute_pose {
 
+class HybridPoseEstimatorOptions {
+public:
+    HybridPoseEstimatorOptions() : 
+        ransac_options(ExtendedHybridLORansacOptions()),
+        lineloc_config(LineLocConfig()),
+        solver_flags(std::vector<bool>{true, true, true, true}),
+        cheirality_min_depth(0.0),
+        cheirality_overlap_pixels(10.0),
+        random(true) {}
+
+    ExtendedHybridLORansacOptions ransac_options;
+    LineLocConfig lineloc_config;
+    std::vector<bool> solver_flags;
+    double cheirality_min_depth;
+    double cheirality_overlap_pixels;
+    bool random = true;
+};
+
 class HybridPoseEstimator : public JointPoseEstimator {
 public:
     HybridPoseEstimator(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, const std::vector<Line2d>& l2ds, 
                         const std::vector<V3D>& p3ds, const std::vector<V2D>& p2ds, 
                         const Camera& cam, const LineLocConfig& cfg,
                         const double cheirality_min_depth = 0.0, 
-                        const double line_min_projected_length = 1) :
-                        JointPoseEstimator(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, cfg, cheirality_min_depth, line_min_projected_length) {}
+                        const double cheirality_overlap_pixels = 10.0) :
+                        JointPoseEstimator(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, cfg, cheirality_min_depth, cheirality_overlap_pixels) {}
 
     inline int num_minimal_solvers() const { return 4; }
 
@@ -102,11 +120,7 @@ std::pair<CameraPose, ransac_lib::HybridRansacStatistics>
 EstimateAbsolutePose_PointLine_Hybrid(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, 
                                       const std::vector<Line2d>& l2ds, const std::vector<V3D>& p3ds, 
                                       const std::vector<V2D>& p2ds, const Camera& cam, 
-                                      const ExtendedHybridLORansacOptions& options_ = ExtendedHybridLORansacOptions(), 
-                                      const LineLocConfig& cfg = LineLocConfig(),
-                                      const std::vector<bool>& solver_flags = std::vector<bool>{true, true, true, true},
-                                      const double cheirality_min_depth = 0.0, 
-                                      const double line_min_projected_length = 1);
+                                      const HybridPoseEstimatorOptions& options);
 
 } // namespace pose
 

--- a/limap/estimators/absolute_pose/joint_pose_estimator.cc
+++ b/limap/estimators/absolute_pose/joint_pose_estimator.cc
@@ -210,9 +210,12 @@ bool JointPoseEstimator::cheirality_test_line(const Line2d& l2d, const Line3d& l
     if (!cheirality_test_point(p_end, pose))
         return false;
 
-    // Check backprojected length
-    double len2d = l3d.projection(CameraView(cam_, pose)).length();
-    if (len2d < line_min_projected_length_) 
+    // check 2D overlap
+    CameraView camview(cam_, pose);
+    Line2d proj_l2d = l3d.projection(camview);
+    V2D p1 = proj_l2d.point_projection(l2d.start);
+    V2D p2 = proj_l2d.point_projection(l2d.end);
+    if (Line2d(p1, p2).length < 10)
         return false;
 
     return true;

--- a/limap/estimators/absolute_pose/joint_pose_estimator.cc
+++ b/limap/estimators/absolute_pose/joint_pose_estimator.cc
@@ -23,19 +23,18 @@ namespace lineloc = optimize::line_localization;
 std::pair<CameraPose, ransac_lib::RansacStatistics> 
 EstimateAbsolutePose_PointLine(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, const std::vector<Line2d>& l2ds, 
                                const std::vector<V3D>& p3ds, const std::vector<V2D>& p2ds, const Camera& cam, 
-                               const ransac_lib::LORansacOptions& options, const lineloc::LineLocConfig& cfg, 
-                               bool sample_solver_first, const double cheirality_min_depth, 
-                               const double line_min_projected_length) {
-    ransac_lib::LORansacOptions ransac_options = options;
+                               const JointPoseEstimatorOptions& options) {
+    ransac_lib::LORansacOptions ransac_options = options.ransac_options;
     std::random_device rand_dev;
-    ransac_options.random_seed_ = rand_dev();
+    if (options.random)
+        ransac_options.random_seed_ = rand_dev();
 
-    JointPoseEstimator solver(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, cfg, cheirality_min_depth, line_min_projected_length);
+    JointPoseEstimator solver(l3ds, l3d_ids, l2ds, p3ds, p2ds, cam, options.lineloc_config, options.cheirality_min_depth, options.cheirality_overlap_pixels);
 
     CameraPose best_model;
     ransac_lib::RansacStatistics ransac_stats;
 
-    if (sample_solver_first) {
+    if (options.sample_solver_first) {
         PointLineAbsolutePoseRansac<CameraPose, std::vector<CameraPose>, JointPoseEstimator> lomsac_solver_first;
         lomsac_solver_first.EstimateModel(ransac_options, solver, &best_model, &ransac_stats);
     }
@@ -49,9 +48,9 @@ EstimateAbsolutePose_PointLine(const std::vector<Line3d>& l3ds, const std::vecto
 JointPoseEstimator::JointPoseEstimator(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, const std::vector<Line2d>& l2ds, 
                                        const std::vector<V3D>& p3ds, const std::vector<V2D>& p2ds, 
                                        const Camera& cam, const lineloc::LineLocConfig& cfg, 
-                                       const double cheirality_min_depth, const double line_min_projected_length) : 
+                                       const double cheirality_min_depth, const double cheirality_overlap_pixels) : 
                                        loc_config_(cfg), cheirality_min_depth_(cheirality_min_depth),
-                                       line_min_projected_length_(line_min_projected_length) {
+                                       cheirality_overlap_pixels_(cheirality_overlap_pixels) {
     l3ds_ = &l3ds;
     l3d_ids_ = &l3d_ids;
     l2ds_ = &l2ds;
@@ -215,7 +214,7 @@ bool JointPoseEstimator::cheirality_test_line(const Line2d& l2d, const Line3d& l
     Line2d proj_l2d = l3d.projection(camview);
     V2D p1 = proj_l2d.point_projection(l2d.start);
     V2D p2 = proj_l2d.point_projection(l2d.end);
-    if (Line2d(p1, p2).length < 10)
+    if (Line2d(p1, p2).length() < cheirality_overlap_pixels_)
         return false;
 
     return true;

--- a/limap/estimators/absolute_pose/joint_pose_estimator.h
+++ b/limap/estimators/absolute_pose/joint_pose_estimator.h
@@ -29,10 +29,10 @@ public:
 
     ransac_lib::LORansacOptions ransac_options;
     LineLocConfig lineloc_config;
-    double cheirality_min_depth;
-    double cheirality_overlap_pixels;
-    bool sample_solver_first;
-    bool random;
+    double cheirality_min_depth = 0.0;
+    double cheirality_overlap_pixels = 10.0;
+    bool sample_solver_first = false;
+    bool random = true;
 };
 
 class JointPoseEstimator {

--- a/limap/estimators/absolute_pose/joint_pose_estimator.h
+++ b/limap/estimators/absolute_pose/joint_pose_estimator.h
@@ -17,13 +17,31 @@ namespace estimators {
 
 namespace absolute_pose {
 
+class JointPoseEstimatorOptions {
+public:
+    JointPoseEstimatorOptions() : 
+        ransac_options(ransac_lib::LORansacOptions()),
+        lineloc_config(LineLocConfig()),
+        cheirality_min_depth(0.0),
+        cheirality_overlap_pixels(10.0),
+        sample_solver_first(false),
+        random(true) {}
+
+    ransac_lib::LORansacOptions ransac_options;
+    LineLocConfig lineloc_config;
+    double cheirality_min_depth;
+    double cheirality_overlap_pixels;
+    bool sample_solver_first;
+    bool random;
+};
+
 class JointPoseEstimator {
 public:
     JointPoseEstimator(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, const std::vector<Line2d>& l2ds, 
                        const std::vector<V3D>& p3ds, const std::vector<V2D>& p2ds, 
                        const Camera& cam, const LineLocConfig& cfg,
                        const double cheirality_min_depth = 0.0, 
-                       const double line_min_projected_length = 1);
+                       const double cheirality_overlap_pixels = 10.0);
 
     inline int min_sample_size() const { return 3; }
 
@@ -61,7 +79,7 @@ protected:
 
     // Cheirality and filtering options
     double cheirality_min_depth_;
-    double line_min_projected_length_;
+    double cheirality_overlap_pixels_;
 
 private:
     bool cheirality_test_point(const V3D& p3d, const CameraPose& pose) const;
@@ -72,9 +90,7 @@ std::pair<CameraPose, ransac_lib::RansacStatistics>
 EstimateAbsolutePose_PointLine(const std::vector<Line3d>& l3ds, const std::vector<int>& l3d_ids, 
                                const std::vector<Line2d>& l2ds, const std::vector<V3D>& p3ds, 
                                const std::vector<V2D>& p2ds, const Camera& cam, 
-                               const ransac_lib::LORansacOptions& options_ = ransac_lib::LORansacOptions(),
-                               const LineLocConfig& cfg = LineLocConfig(), bool sample_solver_first = true,
-                               const double cheirality_min_depth = 0.0, const double line_min_projected_length = 1);
+                               const JointPoseEstimatorOptions& options);
 
 } // namespace pose
 

--- a/limap/optimize/line_localization/bindings.cc
+++ b/limap/optimize/line_localization/bindings.cc
@@ -72,7 +72,7 @@ void bind_line_localization(py::module &m) {
         .def(py::init<py::dict>())
         .def_readwrite("solver_options", &LineLocConfig::solver_options)
         .def_readwrite("print_summary", &LineLocConfig::print_summary)
-        .def_readwrite("normalize_weight", &LineLocConfig::print_summary)
+        .def_readwrite("normalize_weight", &LineLocConfig::normalize_weight)
         .def_readwrite("weight_point", &LineLocConfig::weight_point)
         .def_readwrite("weight_line", &LineLocConfig::weight_line)
         .def_readwrite("cost_function", &LineLocConfig::cost_function)


### PR DESCRIPTION
- Add back overlap check (in 2D instead of 3D) in cheirality test
- Refactor pose estimation configs
- Other fixes