### PR TITLE
auto downloading weights to global directory ~/.limap/models. by default

### DIFF
--- a/cfgs/fitnmerge/default.yaml
+++ b/cfgs/fitnmerge/default.yaml
@@ -2,6 +2,7 @@
 ##############################
 # global config
 cfg_type: "fitnmerge"
+weight_path: "~/.limap/models" 
 load_meta: False
 load_det: False 
 load_fit: False 

--- a/cfgs/localization/default.yaml
+++ b/cfgs/localization/default.yaml
@@ -2,6 +2,7 @@
 ##############################
 # global config
 cfg_type: "lineloc"
+weight_path: "~/.limap/models" 
 load_meta: False
 load_det: False 
 load_match: False

--- a/cfgs/triangulation/default.yaml
+++ b/cfgs/triangulation/default.yaml
@@ -2,6 +2,7 @@
 ##############################
 # global config
 cfg_type: "triangulation"
+weight_path: "~/.limap/models" 
 load_meta: False
 load_det: False 
 load_match: False

--- a/limap/features/models/s2dnet.py
+++ b/limap/features/models/s2dnet.py
@@ -143,6 +143,7 @@ class S2DNet(BaseModel):
             self.load_state_dict(state_dict, strict=False)
 
     def download_s2dnet_model(self, path):
+        # TODO: not supporting global weight_path now. Downloading to current directory.
         import subprocess
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))

--- a/limap/line2d/DeepLSD/deeplsd.py
+++ b/limap/line2d/DeepLSD/deeplsd.py
@@ -21,7 +21,10 @@ class DeepLSDDetector(BaseDetector):
             },
         }
         self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        ckpt = os.path.join(os.path.dirname(__file__), 'deeplsd_md.tar')
+        if self.weight_path is None:
+            ckpt = os.path.join(os.path.dirname(__file__), 'deeplsd_md.tar')
+        else:
+            ckpt = os.path.join(self.weight_path, "line2d", "DeepLSD", 'deeplsd_md.tar')
         if not os.path.isfile(ckpt):
             self.download_model(ckpt)
         ckpt = torch.load(ckpt, map_location='cpu')

--- a/limap/line2d/GlueStick/extractor.py
+++ b/limap/line2d/GlueStick/extractor.py
@@ -18,7 +18,7 @@ class WireframeExtractor(BaseDetector):
     def __init__(self, options = BaseDetectorOptions(), device=None):
         super(WireframeExtractor, self).__init__(options)
         self.device = "cuda" if device is None else device
-        self.sp = SuperPoint({}).eval().to(self.device)
+        self.sp = SuperPoint({'weight_path': self.weight_path}).eval().to(self.device)
         self.wireframe_params = OmegaConf.create({
             'nms_radius': 3,
             'force_num_junctions': False,

--- a/limap/line2d/GlueStick/matcher.py
+++ b/limap/line2d/GlueStick/matcher.py
@@ -13,8 +13,11 @@ class GlueStickMatcher(BaseMatcher):
         super(GlueStickMatcher, self).__init__(extractor, options)
         self.device = "cuda" if device is None else device
         self.gs = GlueStick({}).eval().to(self.device)
-        ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+        if self.weight_path is None:
+            ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'weights/checkpoint_GlueStick_MD.tar')
+        else:
+            ckpt = os.path.join(self.weight_path, "line2d", "GlueStick", 'weights/checkpoint_GlueStick_MD.tar')
         if not os.path.isfile(ckpt):
             self.download_model(ckpt)
         ckpt = torch.load(ckpt, map_location='cpu')['model']
@@ -27,7 +30,7 @@ class GlueStickMatcher(BaseMatcher):
             os.makedirs(os.path.dirname(path))
         link = "https://github.com/cvg/GlueStick/releases/download/v0.1_arxiv/checkpoint_GlueStick_MD.tar"
         cmd = ["wget", link, "-O", path]
-        print("Downloading SuperPoint model...")
+        print("Downloading GlueStick model...")
         subprocess.run(cmd, check=True)
 
     def get_module_name(self):

--- a/limap/line2d/HAWPv3/hawp.py
+++ b/limap/line2d/HAWPv3/hawp.py
@@ -14,8 +14,11 @@ class HAWPv3Detector(BaseDetector):
     def __init__(self, options = BaseDetectorOptions()):
         super(HAWPv3Detector, self).__init__(options)
         # Load the HAWPv3 model
-        ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+        if self.weight_path is None:
+            ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'weights/hawpv3_wireframe.pth')
+        else:
+            ckpt = os.path.join(self.weight_path, "line2d", "HAWPv3", 'weights/hawpv3_wireframe.pth')
         config = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                               'hawpv3.yaml')
         model_config.merge_from_file(config)

--- a/limap/line2d/L2D2/extractor.py
+++ b/limap/line2d/L2D2/extractor.py
@@ -18,8 +18,11 @@ class L2D2Extractor(BaseDetector):
         super(L2D2Extractor, self).__init__(options)
         self.mini_batch = 20
         self.device = 'cuda' if device is None else device
-        ckpt = os.path.join(os.path.dirname(__file__),
+        if self.weight_path is None:
+            ckpt = os.path.join(os.path.dirname(__file__),
                             'checkpoint_line_descriptor.th')
+        else:
+            ckpt = os.path.join(self.weight_path, "line2d", "L2D2", 'checkpoint_line_descriptor.th')
         if not os.path.isfile(ckpt):
             self.download_model(ckpt)
         self.model = torch.load(ckpt).to(self.device)

--- a/limap/line2d/LineTR/extractor.py
+++ b/limap/line2d/LineTR/extractor.py
@@ -18,7 +18,7 @@ class LineTRExtractor(BaseDetector):
         super(LineTRExtractor, self).__init__(options)
         self.device = "cuda" if device is None else device
         self.sp = SuperPoint({}).eval().to(self.device)
-        self.linetr = LineTransformer({}).eval().to(self.device)
+        self.linetr = LineTransformer({'weight_path': self.weight_path}).eval().to(self.device)
 
     def get_module_name(self):
         return "linetr"

--- a/limap/line2d/LineTR/line_transformer.py
+++ b/limap/line2d/LineTR/line_transformer.py
@@ -198,6 +198,7 @@ class LineTransformer(nn.Module):
         'n_heads': 4,
         'n_line_descriptive_layers': 1,
         'd_inner': 1024,    # d_inner at the Feed_Forward Layer
+        'weight_path': None,
     }
 
     def __init__(self, config):
@@ -218,7 +219,10 @@ class LineTransformer(nn.Module):
 
 
         if self.config['mode'] == 'test':
-            path = Path(__file__).parent / 'weights/LineTR_weight.pth'
+            if self.config['weight_path'] is None:
+                path = Path(__file__).parent / 'weights/LineTR_weight.pth'
+            else:
+                path = Path(os.path.join(self.config["weight_path"], "line2d", "LineTR")) / 'weights/LineTR_weight.pth'
             if not path.is_file():
                 self.download_model(path)
             self.load_state_dict(torch.load(str(path)))

--- a/limap/line2d/LineTR/matcher.py
+++ b/limap/line2d/LineTR/matcher.py
@@ -14,7 +14,7 @@ class LineTRMatcher(BaseMatcher):
                  topk=0, device=None):
         super(LineTRMatcher, self).__init__(extractor, options)
         self.device = "cuda" if device is None else device
-        self.linetr = LineTransformer({}).eval().to(self.device)
+        self.linetr = LineTransformer({'weight_path': self.weight_path}).eval().to(self.device)
 
     def get_module_name(self):
         return "linetr"

--- a/limap/line2d/SOLD2/sold2.py
+++ b/limap/line2d/SOLD2/sold2.py
@@ -13,7 +13,7 @@ import limap.util.io as limapio
 class SOLD2Detector(BaseDetector):
     def __init__(self, options = BaseDetectorOptions()):
         super(SOLD2Detector, self).__init__(options)
-        self.detector = SOLD2LineDetector()
+        self.detector = SOLD2LineDetector(weight_path=self.weight_path)
 
     def get_module_name(self):
         return "sold2"
@@ -88,7 +88,7 @@ class SOLD2Matcher(BaseMatcher):
     def __init__(self, extractor, options = BaseMatcherOptions()):
         super(SOLD2Matcher, self).__init__(extractor, options)
         assert self.extractor.get_module_name() == "sold2"
-        self.detector = SOLD2LineDetector()
+        self.detector = SOLD2LineDetector(weight_path=self.weight_path)
 
     def get_module_name(self):
         return "sold2"

--- a/limap/line2d/SOLD2/sold2_wrapper.py
+++ b/limap/line2d/SOLD2/sold2_wrapper.py
@@ -11,15 +11,15 @@ from SOLD2.model.line_matcher import LineMatcher
 
 
 class SOLD2LineDetector():
-    def __init__(self, device=None, cfg_path=None, ckpt_path=None):
-        import os
+    def __init__(self, device=None, cfg_path=None, weight_path=None):
         nowpath = os.path.dirname(os.path.abspath(__file__))
         if cfg_path is None:
             cfg_path = 'config/export_line_features.yaml'
         self.cfg = load_config(os.path.join(nowpath, cfg_path))
-        if ckpt_path is None:
-            ckpt_path = 'pretrained_models/sold2_wireframe.tar'
-        self.ckpt_path = os.path.join(nowpath, ckpt_path)
+        if weight_path is None:
+            self.ckpt_path = os.path.join(nowpath, 'pretrained_models/sold2_wireframe.tar')
+        else:
+            self.ckpt_path = os.path.join(weight_path, "line2d", "SOLD2", "pretrained_models/sold2_wireframe.tar")
         if device is None:
             device = 'cuda'
         self.device = device

--- a/limap/line2d/TP_LSD/tp_lsd.py
+++ b/limap/line2d/TP_LSD/tp_lsd.py
@@ -15,10 +15,23 @@ class TPLSDDetector(BaseDetector):
         super(TPLSDDetector, self).__init__(options)
         # Load the TP-LSD model
         head = {'center': 1, 'dis': 4, 'line': 1}
-        ckpt = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
-                            'third-party/TP-LSD/pretraineds/Res512.pth')
+        if self.weight_path is None:
+            ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pretraineds/Res512.pth')
+        else:
+            ckpt = os.path.join(self.weight_path, "line2d", "TP_LSD", "pretrained/Res512.pth")
+        if not os.path.isfile(ckpt):
+            self.download_model(ckpt)
         self.net = load_model(Res320(head), ckpt)
         self.net = self.net.cuda().eval()
+
+    def download_model(self, path):
+        import subprocess
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        link = "https://github.com/Siyuada7/TP-LSD/blob/master/pretraineds/Res512.pth?raw=true"
+        cmd = ["wget", link, "-O", path]
+        print("Downloading TP_LSD model...")
+        subprocess.run(cmd, check=True)
 
     def get_module_name(self):
         return "tp_lsd"

--- a/limap/line2d/base_detector.py
+++ b/limap/line2d/base_detector.py
@@ -9,8 +9,8 @@ import limap.visualize as limapvis
 
 from collections import namedtuple
 BaseDetectorOptions = namedtuple("BaseDetectorOptions",
-                                 ["set_gray", "max_num_2d_segs", "do_merge_lines", "visualize"],
-                                 defaults=[True, 3000, False, False])
+                                 ["set_gray", "max_num_2d_segs", "do_merge_lines", "visualize", "weight_path"],
+                                 defaults=[True, 3000, False, False, None])
 
 class BaseDetector():
     def __init__(self, options = BaseDetectorOptions()):
@@ -18,6 +18,7 @@ class BaseDetector():
         self.max_num_2d_segs = options.max_num_2d_segs
         self.do_merge_lines = options.do_merge_lines
         self.visualize = options.visualize
+        self.weight_path = options.weight_path
 
     # Module name needs to be set
     def get_module_name(self):

--- a/limap/line2d/base_matcher.py
+++ b/limap/line2d/base_matcher.py
@@ -8,8 +8,8 @@ import limap.util.io as limapio
 
 from collections import namedtuple
 BaseMatcherOptions = namedtuple("BaseMatcherOptions",
-                                ["topk", "n_neighbors", "n_jobs"],
-                                defaults=[10, 20, 1])
+                                ["topk", "n_neighbors", "n_jobs", "weight_path"],
+                                defaults=[10, 20, 1, None])
 
 class BaseMatcher():
     def __init__(self, extractor, options = BaseMatcherOptions()):
@@ -17,6 +17,7 @@ class BaseMatcher():
         self.topk = options.topk
         self.n_neighbors = options.n_neighbors
         self.n_jobs = options.n_jobs
+        self.weight_path = options.weight_path
 
     # The functions below are required for matchers
     def get_module_name(self):

--- a/limap/line2d/endpoints/extractor.py
+++ b/limap/line2d/endpoints/extractor.py
@@ -14,7 +14,7 @@ class SuperPointEndpointsExtractor(BaseDetector):
     def __init__(self, options = BaseDetectorOptions(), device=None):
         super(SuperPointEndpointsExtractor, self).__init__(options)
         self.device = "cuda" if device is None else device
-        self.sp = SuperPoint({}).eval().to(self.device)
+        self.sp = SuperPoint({'weight_path': self.weight_path}).eval().to(self.device)
 
     def get_module_name(self):
         return "superpoint_endpoints"

--- a/limap/line2d/endpoints/matcher.py
+++ b/limap/line2d/endpoints/matcher.py
@@ -15,7 +15,7 @@ class NNEndpointsMatcher(BaseMatcher):
         super(NNEndpointsMatcher, self).__init__(extractor, options)
         assert self.extractor.get_module_name() == "superpoint_endpoints"
         self.device = "cuda" if device is None else device
-        self.sg = SuperGlue(dict()).eval().to(self.device)
+        self.sg = SuperGlue({'weight_path': self.weight_path}).eval().to(self.device)
 
     def get_module_name(self):
         return "nn_endpoints"

--- a/limap/line2d/register_detector.py
+++ b/limap/line2d/register_detector.py
@@ -1,11 +1,11 @@
 from .base_detector import BaseDetectorOptions
 
 def get_detector(cfg_detector, max_num_2d_segs=3000,
-                 do_merge_lines=False, visualize=False):
+                 do_merge_lines=False, visualize=False, weight_path=None):
     options = BaseDetectorOptions()
     options = options._replace(
         set_gray=True, max_num_2d_segs=max_num_2d_segs,
-        do_merge_lines=do_merge_lines, visualize=visualize)
+        do_merge_lines=do_merge_lines, visualize=visualize, weight_path=weight_path)
 
     method = cfg_detector["method"]
     if method == "lsd":
@@ -26,9 +26,9 @@ def get_detector(cfg_detector, max_num_2d_segs=3000,
     else:
         raise NotImplementedError
 
-def get_extractor(cfg_extractor):
+def get_extractor(cfg_extractor, weight_path=None):
     options = BaseDetectorOptions()
-    options = options._replace(set_gray=True)
+    options = options._replace(set_gray=True, weight_path=weight_path)
 
     method = cfg_extractor["method"]
     if method == "sold2":
@@ -51,3 +51,4 @@ def get_extractor(cfg_extractor):
         return WireframeExtractor(options)
     else:
         raise NotImplementedError
+

--- a/limap/line2d/register_matcher.py
+++ b/limap/line2d/register_matcher.py
@@ -1,10 +1,10 @@
 from .base_matcher import BaseMatcherOptions
 
-def get_matcher(cfg_matcher, extractor, n_neighbors=20):
+def get_matcher(cfg_matcher, extractor, n_neighbors=20, weight_path=None):
     options = BaseMatcherOptions()
     options = options._replace(
         n_neighbors=n_neighbors, topk=cfg_matcher["topk"],
-        n_jobs=cfg_matcher["n_jobs"])
+        n_jobs=cfg_matcher["n_jobs"], weight_path=weight_path)
 
     method = cfg_matcher["method"]
     if method == "sold2":

--- a/limap/point2d/superglue/superglue.py
+++ b/limap/point2d/superglue/superglue.py
@@ -170,6 +170,7 @@ class SuperGlue(nn.Module):
         'GNN_layers': ['self', 'cross'] * 9,
         'sinkhorn_iterations': 100,
         'match_threshold': 0.2,
+        'weight_path': None
     }
 
     def __init__(self, config):
@@ -190,7 +191,10 @@ class SuperGlue(nn.Module):
         self.register_parameter('bin_score', bin_score)
 
         assert self.config['weights'] in ['indoor', 'outdoor']
-        path = Path(__file__).parent
+        if self.config["weight_path"] is None:
+            path = Path(__file__).parent
+        else:
+            path = Path(os.path.join(self.config["weight_path"], "point2d", "superglue"))
         path = path / 'weights/superglue_{}.pth'.format(self.config['weights'])
         if not os.path.isfile(path):
             self.download_model(path)

--- a/limap/point2d/superpoint/superpoint.py
+++ b/limap/point2d/superpoint/superpoint.py
@@ -107,6 +107,7 @@ class SuperPoint(nn.Module):
         'keypoint_threshold': 0.005,
         'max_keypoints': -1,
         'remove_borders': 4,
+        'weight_path': None
     }
 
     def __init__(self, config):
@@ -134,7 +135,10 @@ class SuperPoint(nn.Module):
             c5, self.config['descriptor_dim'],
             kernel_size=1, stride=1, padding=0)
 
-        path = Path(__file__).parent / 'weights/superpoint_v1.pth'
+        if self.config["weight_path"] is None:
+            path = Path(__file__).parent / 'weights/superpoint_v1.pth'
+        else:
+            path = os.path.join(self.config["weight_path"], "point2d", "superpoint", "weights/superpoint_v1.pth")
         if not os.path.isfile(path):
             self.download_model(path)
         self.load_state_dict(torch.load(str(path)))

--- a/limap/runners/functions.py
+++ b/limap/runners/functions.py
@@ -18,6 +18,9 @@ def setup(cfg):
     cfg["dir_load"] = folder_load
     print("[LOG] Output dir: {0}".format(cfg["dir_save"]))
     print("[LOG] Loading dir: {0}".format(cfg["dir_load"]))
+    if "weight_path" in cfg and cfg["weight_path"] is not None:
+        cfg["weight_path"] = os.path.expanduser(cfg["weight_path"])
+        print("[LOG] weight dir: {0}".format(cfg["weight_path"]))
     return cfg
 
 def undistort_images(imagecols, output_dir, fname="image_collection_undistorted.npy", load_undistort=False, n_jobs=-1):
@@ -116,6 +119,7 @@ def compute_sfminfos(cfg, imagecols, fname="metainfos.txt"):
     return colmap_output_path, neighbors, ranges
 
 def compute_2d_segs(cfg, imagecols, compute_descinfo=True):
+    weight_path = None if "weight_path" not in cfg else cfg["weight_path"]
     if "extractor" in cfg["line2d"]:
         print("[LOG] Start 2D line detection and description (detector = {0}, extractor = {1}, n_images = {2})...".format(cfg["line2d"]["detector"]["method"], cfg["line2d"]["extractor"]["method"], imagecols.NumImages()))
     else:
@@ -129,14 +133,14 @@ def compute_2d_segs(cfg, imagecols, compute_descinfo=True):
     se_det = cfg["skip_exists"] or cfg["line2d"]["detector"]["skip_exists"]
     if compute_descinfo:
         se_ext = cfg["skip_exists"] or cfg["line2d"]["extractor"]["skip_exists"]
-    detector = limap.line2d.get_detector(cfg["line2d"]["detector"], max_num_2d_segs=cfg["line2d"]["max_num_2d_segs"], do_merge_lines=cfg["line2d"]["do_merge_lines"], visualize=cfg["line2d"]["visualize"])
+    detector = limap.line2d.get_detector(cfg["line2d"]["detector"], max_num_2d_segs=cfg["line2d"]["max_num_2d_segs"], do_merge_lines=cfg["line2d"]["do_merge_lines"], visualize=cfg["line2d"]["visualize"], weight_path=weight_path)
     if not cfg["load_det"]:
         if compute_descinfo and cfg["line2d"]["detector"]["method"] == cfg["line2d"]["extractor"]["method"] and (not cfg["line2d"]["do_merge_lines"]):
             all_2d_segs, descinfo_folder = detector.detect_and_extract_all_images(folder_save, imagecols, skip_exists=(se_det and se_ext))
         else:
             all_2d_segs = detector.detect_all_images(folder_save, imagecols, skip_exists=se_det)
             if compute_descinfo:
-                extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"])
+                extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"], weight_path=weight_path)
                 descinfo_folder = extractor.extract_all_images(folder_save, imagecols, all_2d_segs, skip_exists=se_ext)
     else:
         folder_load = os.path.join(cfg["dir_load"], basedir)
@@ -144,19 +148,20 @@ def compute_2d_segs(cfg, imagecols, compute_descinfo=True):
         all_2d_segs = {id: all_2d_segs[id] for id in imagecols.get_img_ids()}
         descinfo_folder = None
         if compute_descinfo:
-            extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"])
+            extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"], weight_path=weight_path)
             descinfo_folder = extractor.extract_all_images(folder_save, imagecols, all_2d_segs, skip_exists=se_ext)
     if cfg["line2d"]["save_l3dpp"]:
         limapio.save_l3dpp(os.path.join(folder_save, "l3dpp_format"), imagecols, all_2d_segs)
     return all_2d_segs, descinfo_folder
 
 def compute_matches(cfg, descinfo_folder, image_ids, neighbors):
+    weight_path = None if "weight_path" not in cfg else cfg["weight_path"]
     print("[LOG] Start matching 2D lines... (extractor = {0}, matcher = {1}, n_images = {2}, n_neighbors = {3})".format(cfg["line2d"]["extractor"]["method"], cfg["line2d"]["matcher"]["method"], len(image_ids), cfg["n_neighbors"]))
     import limap.line2d
     basedir = os.path.join("line_matchings", cfg["line2d"]["detector"]["method"], "feats_{0}".format(cfg["line2d"]["extractor"]["method"]))
-    extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"])
+    extractor = limap.line2d.get_extractor(cfg["line2d"]["extractor"], weight_path=weight_path)
     se_match = cfg["skip_exists"] or cfg["line2d"]["matcher"]["skip_exists"]
-    matcher = limap.line2d.get_matcher(cfg["line2d"]["matcher"], extractor, n_neighbors=cfg["n_neighbors"])
+    matcher = limap.line2d.get_matcher(cfg["line2d"]["matcher"], extractor, n_neighbors=cfg["n_neighbors"], weight_path=weight_path)
     if not cfg["load_match"]:
         folder_save = os.path.join(cfg["dir_save"], basedir)
         matches_folder = matcher.match_all_neighbors(folder_save, image_ids, neighbors, descinfo_folder, skip_exists=se_match)


### PR DESCRIPTION
To support pip wheels building we want to download the models elsewhere to some global directory. This is done for all the models except for S2DNet (only for featuremetric refinement, left a TODO and fixed later maybe).

Now that all the model weights will be downloaded and structured in "~/.limap/models" by default, while one can also change it with the option "--weight_path"