### PR TITLE
Fix & Refactor I/O for localization runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We provide two query examples for localization from the *Stairs* scene in the [7
 
 To run the examples, for instance the first one:
 ```bash
-python runners/tests/localization.py --data runners/tests/localization_test_data_stairs_1.npy
+python runners/tests/localization.py --data runners/tests/data/localization/localization_test_data_stairs_1.npy
 ```
 
 The script will print the pose error estimated using point-only (hloc), and the pose error estimated by our hybrid point-line localization framework. In addition, two images will be created in the output folder (default to `outputs/test/localization`) showing the inliers point and line correspondences in hybrid localization projected using the two estimated camera pose (by point-only and point+line) onto the query image with 2D point and line detections marked. An improved accuracy of the hybrid point-line method is expected to be observed.

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -54,7 +54,7 @@ To run the examples, for instance the first one:
 
 .. code-block:: bash
 
-    python runners/tests/localization.py --data runners/tests/localization_test_data_stairs_1.npy
+    python runners/tests/localization.py --data runners/tests/data/localization/localization_test_data_stairs_1.npy
 
 The script will print the pose error estimated using point-only (hloc), and the pose error estimated by our hybrid point-line localization framework. In addition, two images will be created in the output folder (default to ``outputs/test/localization``) showing the inliers point and line correspondences in hybrid localization projected using the two estimated camera pose (by point-only and point+line) onto the query image with 2D point and line detections marked. 
 

--- a/limap/estimators/absolute_pose/_pl_estimate_absolute_pose.py
+++ b/limap/estimators/absolute_pose/_pl_estimate_absolute_pose.py
@@ -10,7 +10,12 @@ def _pl_estimate_absolute_pose(cfg, l3ds, l3d_ids, l2ds, p3ds, p2ds, camera, cam
         jointloc_cfg = {}
         if cfg.get('optimize'):
             jointloc_cfg = cfg.get('optimize').copy()
-            jointloc_cfg['loss_function'] = getattr(_ceresbase, jointloc_cfg['loss_func'])(*jointloc_cfg['loss_func_args'])
+            loss_func_args = jointloc_cfg.get('loss_func_args')
+            if jointloc_cfg.get('loss_func') == 'TrivialLoss':
+                loss_func_args = []
+            elif jointloc_cfg.get('loss_func') == 'HuberLoss':
+                assert len(loss_func_args) == 1, 'HuberLoss requires one argument'
+            jointloc_cfg['loss_function'] = getattr(_ceresbase, jointloc_cfg['loss_func'])(*loss_func_args)
             del jointloc_cfg['loss_func'], jointloc_cfg['loss_func_args']
         else:
             jointloc_cfg['loss_function'] = _ceresbase.TrivialLoss()

--- a/limap/util/config.py
+++ b/limap/util/config.py
@@ -61,8 +61,15 @@ def update_config(cfg, unknown, shortcuts):
         else:
             v = unknown[idx+1]
             if val is not None:
-                if argtype == list and v.startswith('['):
-                    v = eval(v)
+                if argtype == list:
+                    if v.startswith('['):
+                        v = eval(v)
+                    else:
+                        for i in range(idx+2, len(unknown)):
+                            if unknown[i].startswith('--'):
+                                break
+                            v += ',' + unknown[i]
+                        v = eval('[' + v + ']')
                 v = argtype(v)
 
         if isinstance(v, str) and (v.lower() == 'none' or v.lower() == 'null'):

--- a/runners/7scenes/localization.py
+++ b/runners/7scenes/localization.py
@@ -59,10 +59,6 @@ def parse_config():
     if cfg['merging']['do_merging'] and '--refinement.disable' not in unknown:
         # disable refinement for fitnmerge
         cfg['refinement']['disable'] = True
-    return cfg, args
-
-def main():
-    cfg, args = parse_config()
 
     # Output path for LIMAP results (tmp)
     if cfg['output_dir'] is None:
@@ -71,6 +67,10 @@ def main():
     if cfg['output_folder'] is None:
         cfg['output_folder'] = 'finaltracks'
     cfg['output_folder'] += '_{}'.format('dense' if args.use_dense_depth else 'sparse')
+    return cfg, args
+
+def main():
+    cfg, args = parse_config()
     cfg = _runners.setup(cfg)
 
     # outputs is for localization-related results
@@ -91,7 +91,7 @@ def main():
     if args.use_dense_depth and cfg['merging']['do_merging']:
         results_joint = results_joint.replace('dense', 'dense_fnm')
     results_point, results_joint = outputs / results_point, outputs / results_joint
-    
+
     ##########################################################
     # [A] hloc point-based localization
     ##########################################################
@@ -99,7 +99,7 @@ def main():
         cfg, args.dataset, args.scene, results_point, test_list, args.num_covis, args.use_dense_depth, logger
     )
     train_ids, query_ids = ids['train'], ids['query']
-    
+
     # Some paths useful for LIMAP localization too
     ref_sfm_path = outputs / ('sfm_superpoint+superglue' + ('+depth' if args.use_dense_depth else ''))
     depth_dir = args.dataset / f'depth/7scenes_{args.scene}/train/depth'

--- a/runners/7scenes/localization.py
+++ b/runners/7scenes/localization.py
@@ -37,8 +37,6 @@ def parse_config():
     arg_parser.add_argument('--dataset', type=Path, required=True, help='7scenes root path')
     arg_parser.add_argument('-s', '--scene', type=str, required=True, help='scene name(s)')
     arg_parser.add_argument('--info_path', type=str, default=None, help='load precomputed info')
-    arg_parser.add_argument('--outputs', type=Path, default='outputs/localization/7scenes',
-                        help='Path to the output directory, default: %(default)s')
 
     arg_parser.add_argument('--query_images', default=None, type=Path, help='Path to the file listing query images')
     arg_parser.add_argument('--eval', default=None, type=Path, help='Path to the result file')
@@ -76,7 +74,7 @@ def main():
     cfg = _runners.setup(cfg)
 
     # outputs is for localization-related results
-    outputs = args.outputs / f'{args.scene}'
+    outputs = Path(cfg['output_dir']) / 'localization'
     outputs.mkdir(exist_ok=True, parents=True)
 
     logger.info(f'Working on scene "{args.scene}".')

--- a/runners/cambridge/localization.py
+++ b/runners/cambridge/localization.py
@@ -36,8 +36,6 @@ def parse_config():
     arg_parser.add_argument('-a', '--vsfm_path', type=str, required=True, help='visualsfm path')
     arg_parser.add_argument('--nvm_file', type=str, default='reconstruction.nvm', help='nvm filename')
     arg_parser.add_argument('--info_path', type=str, default=None, help='load precomputed info')
-    arg_parser.add_argument('--outputs', type=Path, default='outputs/localization/cambridge',
-                        help='Path to the output directory, default: %(default)s')
     
     arg_parser.add_argument('--query_images', default=None, type=Path, help='Path to the file listing query images')
     arg_parser.add_argument('--eval', default=None, type=Path, help='Path to the result file')
@@ -68,10 +66,13 @@ def main():
     # Output path for LIMAP results (tmp)
     if cfg['output_dir'] is None:
         cfg['output_dir'] = 'tmp/cambridge/{}'.format(scene_id)
+    # Output folder for LIMAP linetracks (in tmp)
+    if cfg['output_folder'] is None:
+        cfg['output_folder'] = 'finaltracks'
     cfg = _runners.setup(cfg)
 
     # outputs is for localization-related results
-    outputs = args.outputs / f'{scene_id}'
+    outputs = Path(cfg['output_dir']) / 'localization'
     outputs.mkdir(exist_ok=True, parents=True)
 
     logger.info(f'Working on scene "{scene_id}".')

--- a/runners/cambridge/localization.py
+++ b/runners/cambridge/localization.py
@@ -36,7 +36,7 @@ def parse_config():
     arg_parser.add_argument('-a', '--vsfm_path', type=str, required=True, help='visualsfm path')
     arg_parser.add_argument('--nvm_file', type=str, default='reconstruction.nvm', help='nvm filename')
     arg_parser.add_argument('--info_path', type=str, default=None, help='load precomputed info')
-    
+
     arg_parser.add_argument('--query_images', default=None, type=Path, help='Path to the file listing query images')
     arg_parser.add_argument('--eval', default=None, type=Path, help='Path to the result file')
 
@@ -57,19 +57,18 @@ def parse_config():
     cfg['info_path'] = args.info_path
     cfg['n_neighbors'] = args.num_covis
     cfg['n_neighbors_loc'] = args.num_loc
-    return cfg, args
-
-def main():
-    cfg, args = parse_config()
-    scene_id = os.path.basename(cfg['vsfm_path'])
-
     # Output path for LIMAP results (tmp)
     if cfg['output_dir'] is None:
         cfg['output_dir'] = 'tmp/cambridge/{}'.format(scene_id)
     # Output folder for LIMAP linetracks (in tmp)
     if cfg['output_folder'] is None:
         cfg['output_folder'] = 'finaltracks'
+    return cfg, args
+
+def main():
+    cfg, args = parse_config()
     cfg = _runners.setup(cfg)
+    scene_id = os.path.basename(cfg['vsfm_path'])
 
     # outputs is for localization-related results
     outputs = Path(cfg['output_dir']) / 'localization'

--- a/runners/inloc/localization.py
+++ b/runners/inloc/localization.py
@@ -30,8 +30,6 @@ def parse_config():
     arg_parser.add_argument('--default_config_file', type=str, default='cfgs/localization/default.yaml', help='default config file')
     arg_parser.add_argument('--dataset', type=Path, required=True, help='inloc dataset path')
     arg_parser.add_argument('--info_path', type=str, default=None, help='load precomputed info')
-    arg_parser.add_argument('--outputs', type=Path, default='outputs/localization/inloc',
-                        help='Path to the output directory, default: %(default)s')
 
     arg_parser.add_argument('--num_loc', type=int, default=40,
                         help='Number of image pairs for loc, default: %(default)s')
@@ -60,10 +58,14 @@ def main():
     # Output path for LIMAP results (tmp)
     if cfg['output_dir'] is None:
         cfg['output_dir'] = 'tmp/inloc'
+    # Output folder for LIMAP linetracks (in tmp)
+    if cfg['output_folder'] is None:
+        cfg['output_folder'] = 'finaltracks'
     cfg = _runners.setup(cfg)
 
-    # args.outputs is for localization-related results
-    args.outputs.mkdir(exist_ok=True, parents=True)
+    # outputs is for localization-related results
+    outputs = Path(cfg['output_dir']) / 'localization'
+    outputs.mkdir(exist_ok=True, parents=True)
 
     logger.info(f'Working on InLoc.')
     pairs = Path('third-party/Hierarchical-Localization/pairs/inloc/')
@@ -74,7 +76,7 @@ def main():
         imagecols.set_max_image_dim(cfg["max_image_dim"])
 
     results_point, results_joint = get_result_filenames(cfg['localization'], args.use_temporal)
-    results_point, results_joint = args.outputs / results_point, args.outputs / results_joint
+    results_point, results_joint = outputs / results_point, outputs / results_joint
 
     ##########################################################
     # [A] hloc point-based localization

--- a/runners/inloc/localization.py
+++ b/runners/inloc/localization.py
@@ -49,18 +49,18 @@ def parse_config():
         cfg["refinement"]["disable"] = True
     cfg['info_path'] = args.info_path
     cfg['n_neighbors_loc'] = args.num_loc
-    return cfg, args
 
-def main():
-    cfg, args = parse_config()
-    cfg['inloc_dataset'] = args.dataset # For reading camera poses for estimating 3D lines fron depth 
-    
     # Output path for LIMAP results (tmp)
     if cfg['output_dir'] is None:
         cfg['output_dir'] = 'tmp/inloc'
     # Output folder for LIMAP linetracks (in tmp)
     if cfg['output_folder'] is None:
         cfg['output_folder'] = 'finaltracks'
+    cfg['inloc_dataset'] = args.dataset # For reading camera poses for estimating 3D lines fron depth
+    return cfg, args
+
+def main():
+    cfg, args = parse_config()
     cfg = _runners.setup(cfg)
 
     # outputs is for localization-related results

--- a/runners/tests/localization.py
+++ b/runners/tests/localization.py
@@ -29,7 +29,7 @@ def parse_args():
     arg_parser = argparse.ArgumentParser(description='minimal test for visual localization with points and lines')
     arg_parser.add_argument('--data', type=Path, default='runners/tests/data/localization/localization_test_data_stairs_1.npy',
                             help='Path to test data file, default: %(default)s')
-    arg_parser.add_argument('--outputs', type=Path, default='outputs/test/localization',
+    arg_parser.add_argument('--outputs', type=Path, default='test_outputs/localization',
                             help='Path to the output directory, default: %(default)s')
     arg_parser.add_argument('--ransac_method', choices=['ransac', 'solver', 'hybrid'], default='hybrid',
                             help='RANSAC method')

--- a/runners/tests/localization.py
+++ b/runners/tests/localization.py
@@ -29,7 +29,7 @@ def parse_args():
     arg_parser = argparse.ArgumentParser(description='minimal test for visual localization with points and lines')
     arg_parser.add_argument('--data', type=Path, default='runners/tests/data/localization/localization_test_data_stairs_1.npy',
                             help='Path to test data file, default: %(default)s')
-    arg_parser.add_argument('--outputs', type=Path, default='test_outputs/localization',
+    arg_parser.add_argument('--outputs', type=Path, default='outputs/test/localization',
                             help='Path to the output directory, default: %(default)s')
     arg_parser.add_argument('--ransac_method', choices=['ransac', 'solver', 'hybrid'], default='hybrid',
                             help='RANSAC method')

--- a/runners/tests/localization.py
+++ b/runners/tests/localization.py
@@ -29,7 +29,7 @@ def parse_args():
     arg_parser = argparse.ArgumentParser(description='minimal test for visual localization with points and lines')
     arg_parser.add_argument('--data', type=Path, default='runners/tests/data/localization/localization_test_data_stairs_1.npy',
                             help='Path to test data file, default: %(default)s')
-    arg_parser.add_argument('--outputs', type=Path, default='outputs/test/localization',
+    arg_parser.add_argument('--outputs', type=Path, default='outputs/test_outputs/localization',
                             help='Path to the output directory, default: %(default)s')
     arg_parser.add_argument('--ransac_method', choices=['ransac', 'solver', 'hybrid'], default='hybrid',
                             help='RANSAC method')


### PR DESCRIPTION
- Check `loss_func_args` for corresponding `loss_func` type, command in localization tutorial can now run successfully
- Remove redundant output folder for localization results, use `output_dir` in configs instead