### PR TITLE
Remove normalize_weight options from lineloc configs

### DIFF
--- a/cfgs/localization/7scenes.yaml
+++ b/cfgs/localization/7scenes.yaml
@@ -17,7 +17,6 @@ localization:
         thres_point: 5
         thres_line: 5
     optimize:
-        normalize_weight: False     # For Stairs: Set this to True, and loss_func to TrivialLoss for best performance
         loss_func: "HuberLoss"
         loss_func_args: [1.0]
     line_cost_func: "PerpendicularDist"

--- a/cfgs/localization/cambridge.yaml
+++ b/cfgs/localization/cambridge.yaml
@@ -17,7 +17,6 @@ localization:
         thres_point: 6
         thres_line: 6
     optimize:
-        normalize_weight: False
         loss_func: HuberLoss
         loss_func_args: [1.2]
     line_cost_func: "PerpendicularDist"

--- a/cfgs/localization/default.yaml
+++ b/cfgs/localization/default.yaml
@@ -40,7 +40,6 @@ localization:
         min_num_iterations: 100
         solver_flags: [True, True, True, True]
     optimize:
-        normalize_weight: False
         loss_func: "TrivialLoss"
         loss_func_args: []
     line_cost_func: "PerpendicularDist"

--- a/limap/estimators/absolute_pose/_pl_estimate_absolute_pose.py
+++ b/limap/estimators/absolute_pose/_pl_estimate_absolute_pose.py
@@ -14,7 +14,6 @@ def _pl_estimate_absolute_pose(cfg, l3ds, l3d_ids, l2ds, p3ds, p2ds, camera, cam
             del jointloc_cfg['loss_func'], jointloc_cfg['loss_func_args']
         else:
             jointloc_cfg['loss_function'] = _ceresbase.TrivialLoss()
-            jointloc_cfg['normalize_weight'] = False
 
     # Optimization weight, not for RANSAC scoring
     if 'line_weight' in cfg:

--- a/limap/estimators/absolute_pose/joint_pose_estimator.cc
+++ b/limap/estimators/absolute_pose/joint_pose_estimator.cc
@@ -140,7 +140,6 @@ int JointPoseEstimator::NonMinimalSolver(const std::vector<int>& sample, CameraP
 
     LineLocConfig config = loc_config_;
     config.weight_line = config.weight_point = 1.0;
-    config.normalize_weight = false;
     config.loss_function.reset(new ceres::TrivialLoss()); 
     JointLocEngine loc_engine(config);
     V4D kvec = V4D(cam_.Params().data());

--- a/limap/optimize/line_localization/bindings.cc
+++ b/limap/optimize/line_localization/bindings.cc
@@ -72,7 +72,6 @@ void bind_line_localization(py::module &m) {
         .def(py::init<py::dict>())
         .def_readwrite("solver_options", &LineLocConfig::solver_options)
         .def_readwrite("print_summary", &LineLocConfig::print_summary)
-        .def_readwrite("normalize_weight", &LineLocConfig::normalize_weight)
         .def_readwrite("weight_point", &LineLocConfig::weight_point)
         .def_readwrite("weight_line", &LineLocConfig::weight_line)
         .def_readwrite("cost_function", &LineLocConfig::cost_function)

--- a/limap/optimize/line_localization/lineloc.cc
+++ b/limap/optimize/line_localization/lineloc.cc
@@ -98,14 +98,8 @@ void JointLocEngine::AddResiduals() {
     // ceres::LossFunction* loss_function = new ceres::CauchyLoss(0.1);
     ceres::LossFunction* loss_function = this->config_.loss_function.get();
 
-    int num_lines = this->l3ds.size();
-    int num_points = this->p3ds.size();
-    double weight_lines = double(num_points) / (num_lines + num_points);
-    double weight_points = 1 - weight_lines;
-    if (!this->config_.normalize_weight)
-        weight_lines = weight_points = 1.0;
-    weight_lines *= this->config_.weight_line;
-    weight_points *= this->config_.weight_point;
+    double weight_lines = this->config_.weight_line;
+    double weight_points = this->config_.weight_point;
     
     // add to problem for each pair of lines
     for (int i = 0; i < this->l3ds.size(); i++) {

--- a/limap/optimize/line_localization/lineloc_config.h
+++ b/limap/optimize/line_localization/lineloc_config.h
@@ -59,14 +59,12 @@ public:
         ASSIGN_PYDICT_ITEM(dict, weight_line, double);
         ASSIGN_PYDICT_ITEM(dict, weight_point, double);
         ASSIGN_PYDICT_ITEM(dict, print_summary, bool);
-        ASSIGN_PYDICT_ITEM(dict, normalize_weight, bool);
         ASSIGN_PYDICT_ITEM(dict, loss_function, std::shared_ptr<ceres::LossFunction>);
         if (dict.contains("solver_options"))
             AssignSolverOptionsFromDict(solver_options, dict["solver_options"]);
     }
     double weight_line = 1.0;
     double weight_point = 1.0;
-    bool normalize_weight = true;
     bool points_3d_dist = false;
     
     ceres::Solver::Options solver_options;


### PR DESCRIPTION
The option is removed because using C++ interface without specifying this could be dangerous leading to highly varied results, also confusing.

If needed, the normalization weights could be passed through weight_line and weight_point.