### PR TITLE
Switch to pycolmap.Reconstruction for model converter. Add colmap visualizer with the same backend (Open3D)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,4 +92,5 @@ jobs:
           python runners/hypersim/triangulation.py --default_config_file cfgs/triangulation/default_fast.yaml \
               --output_dir outputs/quickstart_test --triangulation.use_exhaustive_matcher --skip_exists --visualize 0
           python runners/tests/localization.py
+          pytest -m ci_workflow tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist/
 cmake-build-*
 *.egg-info/
+src/hloc
 
 *.npy
 *.png

--- a/limap/base/bindings.cc
+++ b/limap/base/bindings.cc
@@ -678,7 +678,6 @@ void bind_line_linker(py::module &m) {
 }
 
 void bind_camera(py::module &m) {
-  // TODO: use pycolmap
   py::enum_<colmap::CameraModelId> PyCameraModelId(m, "CameraModelId",
                                                    py::module_local());
   PyCameraModelId.value("INVALID", colmap::CameraModelId::kInvalid);

--- a/limap/pointsfm/__init__.py
+++ b/limap/pointsfm/__init__.py
@@ -2,7 +2,6 @@ from _limap import _pointsfm as _pointsfm
 from _limap._pointsfm import *  # noqa: F403
 
 from .colmap_reader import (
-    PyReadCOLMAP,
     ReadPointTracks,
     check_exists_colmap_model,
 )
@@ -20,7 +19,6 @@ from .functions import (
 )
 
 __all__ = [n for n in _pointsfm.__dict__ if not n.startswith("_")] + [
-    "PyReadCOLMAP",
     "ReadPointTracks",
     "check_exists_colmap_model",
     "run_colmap_sfm",

--- a/limap/pointsfm/__init__.py
+++ b/limap/pointsfm/__init__.py
@@ -2,9 +2,9 @@ from _limap import _pointsfm as _pointsfm
 from _limap._pointsfm import *  # noqa: F403
 
 from .colmap_reader import (
+    ReadPointTracks,
     check_exists_colmap_model,
     convert_colmap_to_imagecols,
-    ReadPointTracks,
 )
 from .colmap_sfm import (
     run_colmap_sfm,

--- a/limap/pointsfm/__init__.py
+++ b/limap/pointsfm/__init__.py
@@ -2,8 +2,9 @@ from _limap import _pointsfm as _pointsfm
 from _limap._pointsfm import *  # noqa: F403
 
 from .colmap_reader import (
-    ReadPointTracks,
     check_exists_colmap_model,
+    convert_colmap_to_imagecols,
+    ReadPointTracks,
 )
 from .colmap_sfm import (
     run_colmap_sfm,
@@ -19,8 +20,9 @@ from .functions import (
 )
 
 __all__ = [n for n in _pointsfm.__dict__ if not n.startswith("_")] + [
-    "ReadPointTracks",
     "check_exists_colmap_model",
+    "convert_colmap_to_imagecols",
+    "ReadPointTracks",
     "run_colmap_sfm",
     "run_colmap_sfm_with_known_poses",
     "run_hloc_matches",

--- a/limap/pointsfm/colmap_reader.py
+++ b/limap/pointsfm/colmap_reader.py
@@ -1,9 +1,9 @@
 import os
-import sys
 
-from _limap import _base
 import pycolmap
+from _limap import _base
 from pycolmap import logging
+
 
 def check_exists_colmap_model(model_path):
     if (
@@ -18,7 +18,10 @@ def check_exists_colmap_model(model_path):
         and os.path.exists(os.path.join(model_path, "points3D.txt"))
     )
 
-def convert_colmap_to_imagecols(reconstruction: pycolmap.Reconstruction, image_path=None):
+
+def convert_colmap_to_imagecols(
+    reconstruction: pycolmap.Reconstruction, image_path=None
+):
     # read cameras
     cameras = {}
     for cam_id, colmap_cam in reconstruction.cameras.items():
@@ -38,7 +41,9 @@ def convert_colmap_to_imagecols(reconstruction: pycolmap.Reconstruction, image_p
         qvec = [qvec_xyzw[3], qvec_xyzw[0], qvec_xyzw[1], qvec_xyzw[2]]
         tvec = colmap_image.cam_from_world.translation
         pose = _base.CameraPose(qvec, tvec)
-        image_name = imname if image_path is None else os.path.join(image_path, imname)
+        image_name = (
+            imname if image_path is None else os.path.join(image_path, imname)
+        )
         camimage = _base.CameraImage(cam_id, pose, image_name=image_name)
         camimages[img_id] = camimage
 
@@ -52,8 +57,12 @@ def ReadInfos(colmap_path, model_path="sparse", image_path="images"):
     model_path = os.path.join(colmap_path, model_path)
     image_path = os.path.join(colmap_path, image_path)
     reconstruction = pycolmap.Reconstruction(model_path)
-    logging.info(f"Reconstruction loaded. (n_images = {reconstruction.num_images()}")
-    imagecols = convert_colmap_to_imagecols(reconstruction, image_path=image_path)
+    logging.info(
+        f"Reconstruction loaded. (n_images = {reconstruction.num_images()}"
+    )
+    imagecols = convert_colmap_to_imagecols(
+        reconstruction, image_path=image_path
+    )
     return imagecols
 
 
@@ -66,7 +75,11 @@ def ReadPointTracks(reconstruction: pycolmap.Reconstruction):
         for elem in p.track.elements:
             p_image_ids.append(elem.image_id)
             point2d_ids.append(elem.point2D_idx)
-            p2d_list.append(reconstruction.images[elem.image_id].points2D[elem.point2D_idx].xy)
+            p2d_list.append(
+                reconstruction.images[elem.image_id]
+                .points2D[elem.point2D_idx]
+                .xy
+            )
         ptrack = _base.PointTrack(p.xyz, p_image_ids, point2d_ids, p2d_list)
         pointtracks[point3d_id] = ptrack
     return pointtracks

--- a/limap/pointsfm/colmap_reader.py
+++ b/limap/pointsfm/colmap_reader.py
@@ -57,14 +57,6 @@ def ReadInfos(colmap_path, model_path="sparse", image_path="images"):
     return imagecols
 
 
-def PyReadCOLMAP(colmap_path, model_path=None):
-    if model_path is not None:
-        model_path = os.path.join(colmap_path, model_path)
-    else:
-        model_path = colmap_path
-    return pycolmap.Reconstruction(model_path)
-
-
 def ReadPointTracks(reconstruction: pycolmap.Reconstruction):
     pointtracks = {}
     for point3d_id, p in reconstruction.points3D.items():

--- a/limap/pointsfm/colmap_sfm.py
+++ b/limap/pointsfm/colmap_sfm.py
@@ -8,10 +8,10 @@ import cv2
 import pycolmap
 from pycolmap import logging
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import hloc.utils.database as database
 import hloc.utils.read_write_model as colmap_utils
-from model_converter import convert_imagecols_to_colmap
+
+from limap.pointsfm.model_converter import convert_imagecols_to_colmap
 
 
 def import_images_with_known_cameras(image_dir, database_path, imagecols):

--- a/limap/pointsfm/colmap_sfm.py
+++ b/limap/pointsfm/colmap_sfm.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import cv2
@@ -10,7 +9,6 @@ from pycolmap import logging
 
 import hloc.utils.database as database
 import hloc.utils.read_write_model as colmap_utils
-
 from limap.pointsfm.model_converter import convert_imagecols_to_colmap
 
 

--- a/limap/pointsfm/model_converter.py
+++ b/limap/pointsfm/model_converter.py
@@ -4,11 +4,9 @@ import pycolmap
 from limap.util.geometry import rotation_from_quaternion
 
 import hloc.utils.read_write_model as colmap_utils
-from limap.pointsfm.colmap_reader import PyReadCOLMAP
-
 
 def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):
-    reconstruction = PyReadCOLMAP(colmap_model_path)
+    reconstruction = pycolmap.Reconstruction(colmap_model_path)
     with open(output_nvm_file, "w") as f:
         f.write("NVM_V3\n\n")
 

--- a/limap/pointsfm/model_converter.py
+++ b/limap/pointsfm/model_converter.py
@@ -1,9 +1,9 @@
 import os
+
 import pycolmap
 
-from limap.util.geometry import rotation_from_quaternion
-
 import hloc.utils.read_write_model as colmap_utils
+
 
 def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):
     reconstruction = pycolmap.Reconstruction(colmap_model_path)
@@ -55,7 +55,7 @@ def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):
             f.write(f"{xyz[0]} {xyz[1]} {xyz[2]}")
             f.write(" 128 128 128")  # dummy color
             f.write(f" {len(track.elements)}")
-            for idx, elem in enumerate(track.elements):
+            for _, elem in enumerate(track.elements):
                 img_id = elem.image_id
                 xy_id = elem.point2D_idx
                 img_index = map_image_id[img_id]

--- a/limap/pointsfm/model_converter.py
+++ b/limap/pointsfm/model_converter.py
@@ -1,44 +1,38 @@
 import os
-import sys
+import pycolmap
 
 from limap.util.geometry import rotation_from_quaternion
 
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import hloc.utils.read_write_model as colmap_utils
-from colmap_reader import PyReadCOLMAP
+from limap.pointsfm.colmap_reader import PyReadCOLMAP
 
 
 def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):
     reconstruction = PyReadCOLMAP(colmap_model_path)
-    colmap_cameras, colmap_images, colmap_points = (
-        reconstruction["cameras"],
-        reconstruction["images"],
-        reconstruction["points"],
-    )
     with open(output_nvm_file, "w") as f:
         f.write("NVM_V3\n\n")
 
         # write images
-        f.write(f"{len(colmap_images)}\n")
+        f.write(f"{reconstruction.num_images()}\n")
         map_image_id = dict()
-        for cnt, item in enumerate(colmap_images.items()):
+        for cnt, item in enumerate(reconstruction.images.items()):
             img_id, colmap_image = item
             map_image_id[img_id] = cnt
             img_name = colmap_image.name
             cam_id = colmap_image.camera_id
-            cam = colmap_cameras[cam_id]
-            if cam.model == "SIMPLE_PINHOLE":
+            cam = reconstruction.cameras[cam_id]
+            if cam.model == pycolmap.CameraModelId.SIMPLE_PINHOLE:
                 assert cam.params[1] == 0.5 * cam.width
                 assert cam.params[2] == 0.5 * cam.height
                 focal = cam.params[0]
                 k1 = 0.0
-            elif cam.model == "PINHOLE":
+            elif cam.model == pycolmap.CameraModelId.PINHOLE:
                 assert cam.params[0] == cam.params[1]
                 assert cam.params[2] == 0.5 * cam.width
                 assert cam.params[3] == 0.5 * cam.height
                 focal = cam.params[0]
                 k1 = 0.0
-            elif cam.model == "SIMPLE_RADIAL":
+            elif cam.model == pycolmap.CameraModelId.SIMPLE_RADIAL:
                 assert cam.params[1] == 0.5 * cam.width
                 assert cam.params[2] == 0.5 * cam.height
                 focal = cam.params[0]
@@ -47,33 +41,34 @@ def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):
                 raise ValueError("Camera model not supported in VisualSfM.")
             f.write(f"{img_name}\t")
             f.write(f" {focal}")
-            qvec, tvec = colmap_image.qvec, colmap_image.tvec
-            R = rotation_from_quaternion(qvec)
-            center = -R.transpose() @ tvec
+            qvec_xyzw = colmap_image.cam_from_world.rotation.quat
+            qvec = [qvec_xyzw[3], qvec_xyzw[0], qvec_xyzw[1], qvec_xyzw[2]]
+            center = colmap_image.cam_from_world.inverse().translation
             f.write(f" {qvec[0]} {qvec[1]} {qvec[2]} {qvec[3]}")
             f.write(f" {center[0]} {center[1]} {center[2]}")
             f.write(f" {k1} 0\n")
         f.write("\n")
 
         # write points
-        f.write(f"{len(colmap_points)}\n")
-        for _, point in colmap_points.items():
+        f.write(f"{reconstruction.num_points3D()}\n")
+        for _, point in reconstruction.points3D.items():
             xyz = point.xyz
+            track = point.track
             f.write(f"{xyz[0]} {xyz[1]} {xyz[2]}")
             f.write(" 128 128 128")  # dummy color
-            n_supports = len(point.image_ids)
-            f.write(f" {n_supports}")
-            for idx in range(n_supports):
-                img_id = point.image_ids[idx]
-                xy_id = point.point2D_idxs[idx]
+            f.write(f" {len(track.elements)}")
+            for idx, elem in enumerate(track.elements):
+                img_id = elem.image_id
+                xy_id = elem.point2D_idx
                 img_index = map_image_id[img_id]
                 f.write(f" {img_index} {xy_id}")
-                xy = colmap_images[img_id].xys[xy_id]
+                xy = reconstruction.images[img_id].points2D[xy_id].xy
                 f.write(f" {xy[0]} {xy[1]}")
             f.write("\n")
 
 
 def convert_imagecols_to_colmap(imagecols, colmap_output_path):
+    # TODO: change to pycolmap.Reconstruction
     ### make folders
     if not os.path.exists(colmap_output_path):
         os.makedirs(colmap_output_path)

--- a/limap/runners/line_triangulation.py
+++ b/limap/runners/line_triangulation.py
@@ -1,5 +1,6 @@
 import os
 
+import pycolmap
 from pycolmap import logging
 from tqdm import tqdm
 
@@ -145,7 +146,7 @@ def line_triangulation(cfg, imagecols, neighbors=None, ranges=None):
             colmap_model_path = cfg["triangulation"]["use_pointsfm"][
                 "colmap_folder"
             ]
-        reconstruction = pointsfm.PyReadCOLMAP(colmap_model_path)
+        reconstruction = pycolmap.Reconstruction(colmap_model_path)
         all_bpt2ds, sfm_points = runners.compute_2d_bipartites_from_colmap(
             reconstruction, imagecols, all_2d_lines, cfg["structures"]["bpt2d"]
         )

--- a/limap/visualize/__init__.py
+++ b/limap/visualize/__init__.py
@@ -11,8 +11,8 @@ from .vis_lines import (
     open3d_vis_3d_lines,
 )
 from .vis_utils import (
-    compute_robust_range_points,
     compute_robust_range_lines,
+    compute_robust_range_points,
     draw_segments,
     vis_vpresult,
     visualize_line_track,

--- a/limap/visualize/__init__.py
+++ b/limap/visualize/__init__.py
@@ -11,6 +11,7 @@ from .vis_lines import (
     open3d_vis_3d_lines,
 )
 from .vis_utils import (
+    compute_robust_range_points,
     compute_robust_range_lines,
     draw_segments,
     vis_vpresult,
@@ -28,6 +29,7 @@ __all__ = [
     "open3d_vis_3d_lines",
     "vis_vpresult",
     "draw_segments",
+    "compute_robust_range_points",
     "compute_robust_range_lines",
     "visualize_line_track",
 ]

--- a/limap/visualize/vis_utils.py
+++ b/limap/visualize/vis_utils.py
@@ -334,6 +334,27 @@ def compute_robust_range(arr, range_robust=None, k_stretch=2.0):
     return start_stretched, end_stretched
 
 
+def compute_robust_range_points(points, range_robust=None, k_stretch=2.0):
+    if range_robust is None:
+        range_robust = [0.05, 0.95]
+    points_array = np.array(points)
+    x_array = points_array.reshape(-1, 3)[:, 0]
+    y_array = points_array.reshape(-1, 3)[:, 1]
+    z_array = points_array.reshape(-1, 3)[:, 2]
+
+    x_start, x_end = compute_robust_range(
+        x_array, range_robust=range_robust, k_stretch=k_stretch
+    )
+    y_start, y_end = compute_robust_range(
+        y_array, range_robust=range_robust, k_stretch=k_stretch
+    )
+    z_start, z_end = compute_robust_range(
+        z_array, range_robust=range_robust, k_stretch=k_stretch
+    )
+    ranges = np.array([[x_start, y_start, z_start], [x_end, y_end, z_end]])
+    return ranges
+
+
 def compute_robust_range_lines(lines, range_robust=None, k_stretch=2.0):
     if range_robust is None:
         range_robust = [0.05, 0.95]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    ci_workflow: mark a test as part of the CI workflow
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ imagesize
 einops
 ninja
 yacs
+pytest
 numpy<=1.26.4 # Tag numpy 1.26.4 for Open3D issue (https://github.com/numpy/numpy/issues/26853)
 open3d==0.18.0
 pycolmap>=3.11.1

--- a/tests/base/test_linebase.py
+++ b/tests/base/test_linebase.py
@@ -1,12 +1,17 @@
+import numpy as np
+import numpy.testing as npt
 import pytest
 
 import limap
-import numpy as np
-import numpy.testing as npt
+
 
 @pytest.mark.ci_workflow
 def test_line2d():
     line = limap.base.Line2d(np.array([0.0, 0.0]), np.array([1.0, 1.0]))
     npt.assert_allclose(line.length(), np.sqrt(2), rtol=1e-5, atol=1e-8)
-    npt.assert_allclose(line.direction(), np.array([1., 1.]) / line.length(), rtol=1e-5, atol=1e-8)
-
+    npt.assert_allclose(
+        line.direction(),
+        np.array([1.0, 1.0]) / line.length(),
+        rtol=1e-5,
+        atol=1e-8,
+    )

--- a/tests/base/test_linebase.py
+++ b/tests/base/test_linebase.py
@@ -1,0 +1,12 @@
+import pytest
+
+import limap
+import numpy as np
+import numpy.testing as npt
+
+@pytest.mark.ci_workflow
+def test_line2d():
+    line = limap.base.Line2d(np.array([0.0, 0.0]), np.array([1.0, 1.0]))
+    npt.assert_allclose(line.length(), np.sqrt(2), rtol=1e-5, atol=1e-8)
+    npt.assert_allclose(line.direction(), np.array([1., 1.]) / line.length(), rtol=1e-5, atol=1e-8)
+

--- a/tests/pointsfm/test_colmap_reader.py
+++ b/tests/pointsfm/test_colmap_reader.py
@@ -1,17 +1,24 @@
-import pytest
-import pycolmap
-from limap.pointsfm.colmap_reader import ReadInfos, ReadPointTracks
 import numpy.testing as npt
+import pycolmap
+import pytest
+
+from limap.pointsfm.colmap_reader import ReadInfos, ReadPointTracks
+
 
 @pytest.mark.ci_workflow
 def test_convert_colmap_to_imagecols(tmp_path):
     syn_options = pycolmap.SyntheticDatasetOptions()
     recon = pycolmap.synthesize_dataset(syn_options)
     recon.write(tmp_path)
-    imagecols = ReadInfos(tmp_path, model_path = ".")
+    imagecols = ReadInfos(tmp_path, model_path=".")
     assert imagecols.NumCameras() == recon.num_cameras()
     assert imagecols.NumImages() == recon.num_images()
-    npt.assert_allclose(recon.images[1].cam_from_world.inverse().translation, imagecols.camimage(1).pose.center(), rtol=1e-5, atol=1e-8)
+    npt.assert_allclose(
+        recon.images[1].cam_from_world.inverse().translation,
+        imagecols.camimage(1).pose.center(),
+        rtol=1e-5,
+        atol=1e-8,
+    )
 
 
 @pytest.mark.ci_workflow
@@ -20,4 +27,3 @@ def test_read_point_tracks(tmp_path):
     recon = pycolmap.synthesize_dataset(syn_options)
     point_tracks = ReadPointTracks(recon)
     assert len(point_tracks) == recon.num_points3D()
-

--- a/tests/pointsfm/test_colmap_reader.py
+++ b/tests/pointsfm/test_colmap_reader.py
@@ -1,0 +1,23 @@
+import pytest
+import pycolmap
+from limap.pointsfm.colmap_reader import ReadInfos, ReadPointTracks
+import numpy.testing as npt
+
+@pytest.mark.ci_workflow
+def test_convert_colmap_to_imagecols(tmp_path):
+    syn_options = pycolmap.SyntheticDatasetOptions()
+    recon = pycolmap.synthesize_dataset(syn_options)
+    recon.write(tmp_path)
+    imagecols = ReadInfos(tmp_path, model_path = ".")
+    assert imagecols.NumCameras() == recon.num_cameras()
+    assert imagecols.NumImages() == recon.num_images()
+    npt.assert_allclose(recon.images[1].cam_from_world.inverse().translation, imagecols.camimage(1).pose.center(), rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.ci_workflow
+def test_read_point_tracks(tmp_path):
+    syn_options = pycolmap.SyntheticDatasetOptions()
+    recon = pycolmap.synthesize_dataset(syn_options)
+    point_tracks = ReadPointTracks(recon)
+    assert len(point_tracks) == recon.num_points3D()
+

--- a/tests/pointsfm/test_model_converter.py
+++ b/tests/pointsfm/test_model_converter.py
@@ -1,8 +1,8 @@
-import pytest
 import pycolmap
+import pytest
+
 from limap.pointsfm.model_converter import convert_colmap_to_visualsfm
-from limap.pointsfm.visualsfm_reader import ReadModelVisualSfM
-import numpy.testing as npt
+
 
 @pytest.mark.ci_workflow
 def test_convert_colmap_to_visualsfm(tmp_path):
@@ -11,4 +11,3 @@ def test_convert_colmap_to_visualsfm(tmp_path):
     recon.write(tmp_path)
     output_nvm_file = tmp_path / "test_output.nvm"
     convert_colmap_to_visualsfm(tmp_path, output_nvm_file)
-

--- a/tests/pointsfm/test_model_converter.py
+++ b/tests/pointsfm/test_model_converter.py
@@ -1,0 +1,14 @@
+import pytest
+import pycolmap
+from limap.pointsfm.model_converter import convert_colmap_to_visualsfm
+from limap.pointsfm.visualsfm_reader import ReadModelVisualSfM
+import numpy.testing as npt
+
+@pytest.mark.ci_workflow
+def test_convert_colmap_to_visualsfm(tmp_path):
+    syn_options = pycolmap.SyntheticDatasetOptions()
+    recon = pycolmap.synthesize_dataset(syn_options)
+    recon.write(tmp_path)
+    output_nvm_file = tmp_path / "test_output.nvm"
+    convert_colmap_to_visualsfm(tmp_path, output_nvm_file)
+

--- a/tests/third-party/test_open3d.py
+++ b/tests/third-party/test_open3d.py
@@ -1,8 +1,14 @@
-import pytest
-
 import numpy as np
 import open3d as o3d
+import pytest
+
 
 @pytest.mark.ci_workflow
 def test_open3d():
-    o3d.geometry.LineSet.create_camera_visualization(500, 500, np.array([[500., 0., 250.], [0., 500., 250.], [0., 0., 1.]]), np.eye(4), scale=1.0)
+    o3d.geometry.LineSet.create_camera_visualization(
+        500,
+        500,
+        np.array([[500.0, 0.0, 250.0], [0.0, 500.0, 250.0], [0.0, 0.0, 1.0]]),
+        np.eye(4),
+        scale=1.0,
+    )

--- a/tests/third-party/test_open3d.py
+++ b/tests/third-party/test_open3d.py
@@ -1,0 +1,8 @@
+import pytest
+
+import numpy as np
+import open3d as o3d
+
+@pytest.mark.ci_workflow
+def test_open3d():
+    o3d.geometry.LineSet.create_camera_visualization(500, 500, np.array([[500., 0., 250.], [0., 500., 250.], [0., 0., 1.]]), np.eye(4), scale=1.0)

--- a/tests/third-party/test_pycolmap.py
+++ b/tests/third-party/test_pycolmap.py
@@ -1,12 +1,13 @@
+import pycolmap
 import pytest
 
-import pycolmap
 
 @pytest.mark.ci_workflow
 def test_pycolmap():
-    syn_options = pycolmap.SyntheticDatasetOptions(num_cameras=3, num_images=8, num_points3D=100)
+    syn_options = pycolmap.SyntheticDatasetOptions(
+        num_cameras=3, num_images=8, num_points3D=100
+    )
     recon = pycolmap.synthesize_dataset(syn_options)
     assert recon.num_cameras() == 3
     assert recon.num_images() == 8
     assert recon.num_points3D() == 100
-

--- a/tests/third-party/test_pycolmap.py
+++ b/tests/third-party/test_pycolmap.py
@@ -1,0 +1,12 @@
+import pytest
+
+import pycolmap
+
+@pytest.mark.ci_workflow
+def test_pycolmap():
+    syn_options = pycolmap.SyntheticDatasetOptions(num_cameras=3, num_images=8, num_points3D=100)
+    recon = pycolmap.synthesize_dataset(syn_options)
+    assert recon.num_cameras() == 3
+    assert recon.num_images() == 8
+    assert recon.num_points3D() == 100
+

--- a/visualize_colmap_model.py
+++ b/visualize_colmap_model.py
@@ -1,6 +1,7 @@
-import pycolmap
 import numpy as np
 import open3d as o3d
+import pycolmap
+
 import limap.pointsfm as pointsfm
 import limap.visualize as limapvis
 
@@ -8,13 +9,11 @@ import limap.visualize as limapvis
 def parse_args():
     import argparse
 
-    arg_parser = argparse.ArgumentParser(description="visualize colmap model using Open3D backend")
+    arg_parser = argparse.ArgumentParser(
+        description="visualize colmap model using Open3D backend"
+    )
     arg_parser.add_argument(
-        "-i",
-        "--input_dir",
-        type=str,
-        required=True,
-        help="input colmap folder"
+        "-i", "--input_dir", type=str, required=True, help="input colmap folder"
     )
     arg_parser.add_argument(
         "--use_robust_ranges",
@@ -36,6 +35,7 @@ def parse_args():
     args = arg_parser.parse_args()
     return args
 
+
 def vis_colmap_reconstruction(recon: pycolmap.Reconstruction, ranges=None):
     vis = o3d.visualization.Visualizer()
     vis.create_window(height=1080, width=1920)
@@ -53,6 +53,7 @@ def vis_colmap_reconstruction(recon: pycolmap.Reconstruction, ranges=None):
     vis.run()
     vis.destroy_window()
 
+
 def main(args):
     recon = pycolmap.Reconstruction(args.input_dir)
     ranges = None
@@ -60,6 +61,7 @@ def main(args):
         points = np.array([point.xyz for _, point in recon.points3D.items()])
         ranges = limapvis.compute_robust_range_points(points)
     vis_colmap_reconstruction(recon, ranges=ranges)
+
 
 if __name__ == "__main__":
     args = parse_args()

--- a/visualize_colmap_model.py
+++ b/visualize_colmap_model.py
@@ -1,0 +1,66 @@
+import pycolmap
+import numpy as np
+import open3d as o3d
+import limap.pointsfm as pointsfm
+import limap.visualize as limapvis
+
+
+def parse_args():
+    import argparse
+
+    arg_parser = argparse.ArgumentParser(description="visualize colmap model using Open3D backend")
+    arg_parser.add_argument(
+        "-i",
+        "--input_dir",
+        type=str,
+        required=True,
+        help="input colmap folder"
+    )
+    arg_parser.add_argument(
+        "--use_robust_ranges",
+        action="store_true",
+        help="whether to use computed robust ranges",
+    )
+    arg_parser.add_argument(
+        "--scale",
+        type=float,
+        default=1.0,
+        help="scaling both the lines and the camera geometry",
+    )
+    arg_parser.add_argument(
+        "--cam_scale",
+        type=float,
+        default=1.0,
+        help="scale of the camera geometry",
+    )
+    args = arg_parser.parse_args()
+    return args
+
+def vis_colmap_reconstruction(recon: pycolmap.Reconstruction, ranges=None):
+    vis = o3d.visualization.Visualizer()
+    vis.create_window(height=1080, width=1920)
+    points = np.array([point.xyz for _, point in recon.points3D.items()])
+    pcd = limapvis.open3d_get_points(points, ranges=ranges)
+    vis.add_geometry(pcd)
+    imagecols = pointsfm.convert_colmap_to_imagecols(recon)
+    camera_set = limapvis.open3d_get_cameras(
+        imagecols,
+        ranges=ranges,
+        scale_cam_geometry=args.scale * args.cam_scale,
+        scale=args.scale,
+    )
+    vis.add_geometry(camera_set)
+    vis.run()
+    vis.destroy_window()
+
+def main(args):
+    recon = pycolmap.Reconstruction(args.input_dir)
+    ranges = None
+    if args.use_robust_ranges:
+        points = np.array([point.xyz for _, point in recon.points3D.items()])
+        ranges = limapvis.compute_robust_range_points(points)
+    vis_colmap_reconstruction(recon, ranges=ranges)
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
Dependent on upstream https://github.com/cvg/limap/pull/120

* Switch to pycolmap.Reconstruction from the deprecated namedcollections and remove ``PyReadCOLMAP``
* Add some additional Python tests in the tests folder. Set up pytest and add it to CI. We should migrate the e2e test in the tests folder as well, but this will require merging the dataset implementation into the limap package. 
* Add colmap visualizer with the same Open3D backend, to make the visualization consistent with the line maps. Also support robust ranges to prune outlier points. 