### PR TITLE
Upgrade Python formatter to ruff 0.8.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config: [
-          {os: ubuntu-latest, python-version: "3.8"},
           {os: ubuntu-latest, python-version: "3.9"},
           {os: ubuntu-latest, python-version: "3.10"},
           {os: ubuntu-latest, python-version: "3.11"},

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -37,7 +37,7 @@ jobs:
             exit 0
           fi
           set +x -euo pipefail
-          python -m pip install ruff==0.6.7 clang-format==19.1.0
+          python -m pip install ruff==0.8.6 clang-format==19.1.0
           ./scripts/format/clang_format.sh
           ./scripts/format/python.sh
           git diff --name-only

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In this project, we provide interfaces for various geometric operations on 2D/3D
 ## Installation
 
 **Install the dependencies as follows:**
-* Python 3.8/9/10/11
+* Python 3.9/10/11
 * CMake >= 3.17
 * CUDA (for deep learning based detectors/matchers)
 * System dependencies [[Command line](./misc/install/dependencies.md)]

--- a/limap/features/models/s2dnet.py
+++ b/limap/features/models/s2dnet.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import torch
@@ -64,7 +63,7 @@ def print_gpu_memory():
 class AdapLayers(nn.Module):
     """Small adaptation layers."""
 
-    def __init__(self, hypercolumn_layers: List[str], output_dim: int = 128):
+    def __init__(self, hypercolumn_layers: list[str], output_dim: int = 128):
         """Initialize one adaptation layer for every extraction point.
         Args:
             hypercolumn_layers: The list of the hypercolumn layer names.
@@ -84,7 +83,7 @@ class AdapLayers(nn.Module):
             self.layers.append(layer)
             self.add_module(f"adap_layer_{i}", layer)
 
-    def forward(self, features: List[torch.tensor]):
+    def forward(self, features: list[torch.tensor]):
         """Apply adaptation layers."""
         for i, _ in enumerate(features):
             features[i] = getattr(self, f"adap_layer_{i}")(features[i])

--- a/limap/fitting/fitting.py
+++ b/limap/fitting/fitting.py
@@ -1,6 +1,7 @@
 import numpy as np
 from _limap import _estimators, _fitting
 from bresenham import bresenham
+
 from hloc.localize_inloc import interpolate_scan
 
 

--- a/limap/point2d/superglue/superglue.py
+++ b/limap/point2d/superglue/superglue.py
@@ -43,14 +43,13 @@
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import List, Tuple
 
 import torch
 from pycolmap import logging
 from torch import nn
 
 
-def MLP(channels: List[int], do_bn: bool = True) -> nn.Module:
+def MLP(channels: list[int], do_bn: bool = True) -> nn.Module:
     """Multi-layer perceptron"""
     n = len(channels)
     layers = []
@@ -78,7 +77,7 @@ def normalize_keypoints(kpts, image_shape):
 class KeypointEncoder(nn.Module):
     """Joint encoding of visual appearance and location using MLPs"""
 
-    def __init__(self, feature_dim: int, layers: List[int]) -> None:
+    def __init__(self, feature_dim: int, layers: list[int]) -> None:
         super().__init__()
         self.encoder = MLP([3] + layers + [feature_dim])
         nn.init.constant_(self.encoder[-1].bias, 0.0)
@@ -90,7 +89,7 @@ class KeypointEncoder(nn.Module):
 
 def attention(
     query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     dim = query.shape[1]
     scores = torch.einsum("bdhn,bdhm->bhnm", query, key) / dim**0.5
     prob = torch.nn.functional.softmax(scores, dim=-1)
@@ -135,7 +134,7 @@ class AttentionalPropagation(nn.Module):
 
 
 class AttentionalGNN(nn.Module):
-    def __init__(self, feature_dim: int, layer_names: List[str]) -> None:
+    def __init__(self, feature_dim: int, layer_names: list[str]) -> None:
         super().__init__()
         self.layers = nn.ModuleList(
             [
@@ -147,7 +146,7 @@ class AttentionalGNN(nn.Module):
 
     def forward(
         self, desc0: torch.Tensor, desc1: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         for layer, name in zip(self.layers, self.names):
             if name == "cross":
                 src0, src1 = desc1, desc0

--- a/limap/point2d/superpoint/main.py
+++ b/limap/point2d/superpoint/main.py
@@ -1,15 +1,16 @@
 import collections.abc as collections
 import pprint
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import h5py
 import numpy as np
 import torch
-from hloc import extract_features
-from hloc.utils.io import list_h5_names
 from pycolmap import logging
 from tqdm import tqdm
+
+from hloc import extract_features
+from hloc.utils.io import list_h5_names
 
 from .superpoint import SuperPoint
 
@@ -34,11 +35,11 @@ def map_tensor(input_, func):
 
 @torch.no_grad()
 def run_superpoint(
-    conf: Dict,
+    conf: dict,
     image_dir: Path,
     export_dir: Optional[Path] = None,
     as_half: bool = True,
-    image_list: Optional[Union[Path, List[str]]] = None,
+    image_list: Optional[Union[Path, list[str]]] = None,
     feature_path: Optional[Path] = None,
     overwrite: bool = False,
     keypoints=None,

--- a/limap/pointsfm/colmap_sfm.py
+++ b/limap/pointsfm/colmap_sfm.py
@@ -9,9 +9,10 @@ import pycolmap
 from pycolmap import logging
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from model_converter import convert_imagecols_to_colmap
+
 import hloc.utils.database as database
 import hloc.utils.read_write_model as colmap_utils
-from model_converter import convert_imagecols_to_colmap
 
 
 def import_images_with_known_cameras(image_dir, database_path, imagecols):

--- a/limap/pointsfm/model_converter.py
+++ b/limap/pointsfm/model_converter.py
@@ -4,8 +4,9 @@ import sys
 from limap.util.geometry import rotation_from_quaternion
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import hloc.utils.read_write_model as colmap_utils
 from colmap_reader import PyReadCOLMAP
+
+import hloc.utils.read_write_model as colmap_utils
 
 
 def convert_colmap_to_visualsfm(colmap_model_path, output_nvm_file):

--- a/limap/runners/hybrid_localization.py
+++ b/limap/runners/hybrid_localization.py
@@ -2,7 +2,6 @@ import os
 from collections import defaultdict
 
 import numpy as np
-from hloc.utils.io import get_keypoints, get_matches
 from pycolmap import logging
 from tqdm import tqdm
 
@@ -11,6 +10,7 @@ import limap.estimators as estimators
 import limap.line2d
 import limap.runners as runners
 import limap.util.io as limapio
+from hloc.utils.io import get_keypoints, get_matches
 from limap.optimize.hybrid_localization.functions import (
     filter_line_2to2_epipolarIoU,
     get_reprojection_dist_func,

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,6 +15,7 @@ select = [
     # isort
     "I",
 ]
+ignore = ['I001']
 
 [lint.per-file-ignores]
 "limap/line2d/L2D2/RAL_net_cov.py" = ["SIM"]

--- a/runners/7scenes/localization.py
+++ b/runners/7scenes/localization.py
@@ -10,9 +10,7 @@ import logging
 import pickle
 from pathlib import Path
 
-import hloc.utils.read_write_model as colmap_utils
 import pycolmap
-from hloc.utils.parsers import parse_retrieval
 from utils import (
     DepthReader,
     evaluate,
@@ -22,9 +20,11 @@ from utils import (
     run_hloc_7scenes,
 )
 
+import hloc.utils.read_write_model as colmap_utils
 import limap.runners as runners
 import limap.util.config as cfgutils
 import limap.util.io as limapio
+from hloc.utils.parsers import parse_retrieval
 
 formatter = logging.Formatter(
     fmt="[%(asctime)s %(name)s %(levelname)s] %(message)s",

--- a/runners/7scenes/utils.py
+++ b/runners/7scenes/utils.py
@@ -7,6 +7,11 @@ import PIL
 import PIL.Image
 import pycolmap
 import torch
+from tqdm import tqdm
+
+import limap.base as base
+import limap.pointsfm as pointsfm
+import limap.util.io as limapio
 from hloc import (
     extract_features,
     localize_sfm,
@@ -19,11 +24,6 @@ from hloc.pipelines.Cambridge.utils import (
     evaluate,
 )
 from hloc.utils.read_write_model import read_model, write_model
-from tqdm import tqdm
-
-import limap.base as base
-import limap.pointsfm as pointsfm
-import limap.util.io as limapio
 
 ###############################################################################
 # The following utils functions are taken/modified from hloc.pipelines.7scenes

--- a/runners/cambridge/localization.py
+++ b/runners/cambridge/localization.py
@@ -10,7 +10,6 @@ import logging
 import pickle
 from pathlib import Path
 
-from hloc.utils.parsers import parse_retrieval
 from utils import (
     eval,
     get_result_filenames,
@@ -23,6 +22,7 @@ from utils import (
 import limap.runners as runners
 import limap.util.config as cfgutils
 import limap.util.io as limapio
+from hloc.utils.parsers import parse_retrieval
 
 formatter = logging.Formatter(
     fmt="[%(asctime)s %(name)s %(levelname)s] %(message)s",

--- a/runners/cambridge/utils.py
+++ b/runners/cambridge/utils.py
@@ -11,17 +11,17 @@ from pathlib import Path
 
 import imagesize
 import pycolmap
+from tqdm import tqdm
+
+import limap.base as base
+import limap.pointsfm as pointsfm
+import limap.util.io as limapio
 from hloc import (
     extract_features,
     localize_sfm,
     match_features,
     pairs_from_retrieval,
 )
-from tqdm import tqdm
-
-import limap.base as base
-import limap.pointsfm as pointsfm
-import limap.util.io as limapio
 
 
 def read_scene_visualsfm(

--- a/runners/inloc/utils.py
+++ b/runners/inloc/utils.py
@@ -3,13 +3,13 @@ from pathlib import Path
 
 import imagesize
 import numpy as np
-from hloc import extract_features, localize_inloc, match_features
-from hloc.utils.parsers import parse_retrieval
 from scipy.io import loadmat
 from tqdm import tqdm
 
 import limap.base as base
 import limap.util.io as limapio
+from hloc import extract_features, localize_inloc, match_features
+from hloc.utils.parsers import parse_retrieval
 
 
 class InLocP3DReader(base.BaseP3DReader):

--- a/scripts/format/python.sh
+++ b/scripts/format/python.sh
@@ -4,7 +4,7 @@
 
 # Check version
 version_string=$(ruff --version | sed -E 's/^.*(\d+\.\d+-.*).*$/\1/')
-expected_version_string='0.6.7'
+expected_version_string='0.8.6'
 if [[ "$version_string" =~ "$expected_version_string" ]]; then
     echo "ruff version '$version_string' matches '$expected_version_string'"
 else

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     name="limap",
     version="1.0.0",
     packages=find_packages(),
-    python_requires=">=3.8, < 3.12",
+    python_requires=">=3.9, < 3.12",
     author="Shaohui Liu",
     author_email="b1ueber2y@gmail.com",
     description="A toolbox for mapping and localization with line features",


### PR DESCRIPTION
The ruff formatter from the CI machine does not agree with my local workspace on rule I001, although the version is the same. Ignoring it for now as a temporary solution. 