### PR TITLE
Fix pycolmap convention change for 2D bipartite construction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,4 +99,8 @@ jobs:
               --output_dir outputs/quickstart_test --visualize 0
           python runners/hypersim/triangulation.py --default_config_file cfgs/triangulation/default_fast.yaml \
               --output_dir outputs/quickstart_test --triangulation.use_exhaustive_matcher --skip_exists --visualize 0
+          python runners/colmap_triangulation.py -a outputs/quickstart_test/colmap_outputs \
+              --default_config_file cfgs/triangulation/default_fast.yaml \
+              --output_dir outputs/quickstart_test_colmap --triangulation.use_exhaustive_matcher --visualize 0 \
+              --triangulation.use_pointsfm.enable --triangulation.use_pointsfm.colmap_folder outputs/quickstart_test/colmap_outputs/sparse
 

--- a/limap/runners/functions_structures.py
+++ b/limap/runners/functions_structures.py
@@ -87,11 +87,13 @@ def compute_2d_bipartites_from_colmap(
     cfg_bpt2d = structures.PL_Bipartite2dConfig(cfg)
     logging.info("Start computing 2D bipartites...")
     for img_id, colmap_image in tqdm(reconstruction.images.items()):
-        n_points = colmap_image.xys.shape[0]
+        xys = np.array([p2d.xy for p2d in colmap_image.points2D])
+        n_points = xys.shape[0]
         indexes = np.arange(0, n_points)
-        xys = colmap_image.xys
-        point3D_ids = colmap_image.point3D_ids
-        mask = colmap_image.point3D_ids >= 0
+        point3D_ids = np.array(
+            [p2d.point3D_id for p2d in colmap_image.points2D]
+        )
+        mask = point3D_ids >= 0
 
         # resize xys if needed
         cam_id = imagecols.camimage(img_id).cam_id

--- a/limap/runners/functions_structures.py
+++ b/limap/runners/functions_structures.py
@@ -86,13 +86,16 @@ def compute_2d_bipartites_from_colmap(
     all_bpt2ds = {}
     cfg_bpt2d = structures.PL_Bipartite2dConfig(cfg)
     logging.info("Start computing 2D bipartites...")
+    # TODO: use pycolmap when a new release is available: https://github.com/colmap/colmap/pull/3072
+    INVALID_POINT3D_ID = 2**64 - 1
     for img_id, colmap_image in tqdm(reconstruction.images.items()):
         xys = np.array([p2d.xy for p2d in colmap_image.points2D])
         n_points = xys.shape[0]
         indexes = np.arange(0, n_points)
         point3D_ids = np.array(
             [p2d.point3D_id for p2d in colmap_image.points2D]
-        )
+        ).astype(int)
+        point3D_ids[point3D_ids == INVALID_POINT3D_ID] = -1
         mask = point3D_ids >= 0
 
         # resize xys if needed


### PR DESCRIPTION
Fixes: https://github.com/cvg/limap/issues/133

Missed from https://github.com/cvg/limap/commit/abb923eed6bf16df51625d7de7d53f635e56508f. I added a test in this CI to catch this issue. 