### PR TITLE
Fix Deeplsd model loading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LIMAP 
 
-**The documentations on brief tutorials and APIs are available [here](http://b1ueber2y.me/projects/LIMAP/docs/)**.
+**The documentations on brief tutorials and APIs are available [here](https://b1ueber2y.me/projects/LIMAP/docs/)**.
 
 <p align="center">
 <img src="./misc/media/supp_qualitative_5x3.png">

--- a/limap/line2d/DeepLSD/deeplsd.py
+++ b/limap/line2d/DeepLSD/deeplsd.py
@@ -33,7 +33,7 @@ class DeepLSDDetector(BaseDetector):
             )
         if not os.path.isfile(ckpt):
             self.download_model(ckpt)
-        ckpt = torch.load(ckpt, map_location="cpu")
+        ckpt = torch.load(ckpt, map_location="cpu", weights_only=False)
         self.net = DeepLSD(conf).eval()
         self.net.load_state_dict(ckpt["model"])
         self.net = self.net.to(self.device)


### PR DESCRIPTION
Otherwise this error is met:

_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.                                                                         
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code exec
ution. Do it only if you got the file from a trusted source.                                                                                                                                                                                            
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.                                                                                                                          
        WeightsUnpickler error: Unsupported global: GLOBAL omegaconf.dictconfig.DictConfig was not an allowed global by default. Please use `torch.serialization.add_safe_globals([omegaconf.dictconfig.DictConfig])` or the `torch.serialization.safe_g
lobals([omegaconf.dictconfig.DictConfig])` context manager to allowlist this global if you trust this class/function.